### PR TITLE
Move to extension-ci-tools's workflows (that should work on _rtools)

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   duckdb-stable-build:
     name: Build extension binaries
-    uses: duckdb/duckdb/.github/workflows/_extension_distribution.yml@4145ec87294a4df8fee72e3cdb52f5b0ed02153b
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v0.10.1
     with:
       vcpkg_commit: a42af01b72c28a8e1d7b48107b33e4f286a55ef6
       duckdb_version: v0.10.1


### PR DESCRIPTION
Follow up of https://github.com/duckdb/extension-ci-tools/pull/9, now _rtools should not fail anymore due to missing ccache