### PR TITLE
Move to LoadInternal pattern, allowing extension_version to be there

### DIFF
--- a/src/vss_extension.cpp
+++ b/src/vss_extension.cpp
@@ -31,8 +31,7 @@ std::string VssExtension::Name() {
 extern "C" {
 
 DUCKDB_EXTENSION_API void vss_init(duckdb::DatabaseInstance &db) {
-	duckdb::DuckDB db_wrapper(db);
-	db_wrapper.LoadExtension<duckdb::VssExtension>();
+	LoadInternal(db);
 }
 
 DUCKDB_EXTENSION_API const char *vss_version() {

--- a/test/sql/base/version.test
+++ b/test/sql/base/version.test
@@ -1,0 +1,8 @@
+require-env LOCAL_EXTENSION_REPO
+
+require vss
+
+query I
+SELECT count(*) FROM duckdb_extensions() WHERE extension_name == 'vss' AND extension_version IS NOT NULL AND extension_version != '';
+----
+1


### PR DESCRIPTION
This should allow to have version information available, that is otherwise skipped in the current model.

Test is weak, given is not triggered by vss CI, but should work correctly in main duckdb CI.

This is to be considered for backporting also to v0.10.2.