### PR TITLE
Fully parallelize index construction

### DIFF
--- a/src/hnsw/hnsw_index.cpp
+++ b/src/hnsw/hnsw_index.cpp
@@ -306,10 +306,10 @@ unique_ptr<IndexScanState> HNSWIndex::InitializeScan(float *query_vector, idx_t 
 	auto ef_search = index.expansion_search();
 
 	Value hnsw_ef_search_opt;
-	if(context.TryGetCurrentSetting("hnsw_ef_search", hnsw_ef_search_opt)) {
-		if(!hnsw_ef_search_opt.IsNull() && hnsw_ef_search_opt.type() == LogicalType::BIGINT) {
+	if (context.TryGetCurrentSetting("hnsw_ef_search", hnsw_ef_search_opt)) {
+		if (!hnsw_ef_search_opt.IsNull() && hnsw_ef_search_opt.type() == LogicalType::BIGINT) {
 			auto val = hnsw_ef_search_opt.GetValue<int64_t>();
-			if(val > 0) {
+			if (val > 0) {
 				ef_search = static_cast<idx_t>(val);
 			}
 		}

--- a/src/hnsw/hnsw_index_physical_create.cpp
+++ b/src/hnsw/hnsw_index_physical_create.cpp
@@ -62,13 +62,6 @@ unique_ptr<GlobalSinkState> PhysicalCreateHNSWIndex::GetGlobalSinkState(ClientCo
 	                         info->options, IndexStorageInfo(), estimated_cardinality);
 
 	return std::move(gstate);
-	/*
-
-	// Create the global index
-
-
-	return std::move(gstate);
-	*/
 }
 
 //-------------------------------------------------------------
@@ -99,24 +92,6 @@ SinkResultType PhysicalCreateHNSWIndex::Sink(ExecutionContext &context, DataChun
 	auto &lstate = input.local_state.Cast<CreateHNSWIndexLocalState>();
 	lstate.collection->Append(lstate.append_state, chunk);
 	return SinkResultType::NEED_MORE_INPUT;
-
-	// auto &index = *gstate.global_index;
-	/*
-
-	if (lstate.thread_id == idx_t(-1)) {
-	    lstate.thread_id = gstate.next_thread_id++;
-	}
-
-	if (chunk.ColumnCount() != 2) {
-	    throw NotImplementedException("Custom index creation only supported for single-column indexes");
-	}
-
-	auto &row_identifiers = chunk.data[1];
-
-	// Construct the index
-	index.Construct(chunk, row_identifiers, lstate.thread_id);
-	*/
-	// return SinkResultType::NEED_MORE_INPUT;
 }
 
 //-------------------------------------------------------------

--- a/src/hnsw/hnsw_index_pragmas.cpp
+++ b/src/hnsw/hnsw_index_pragmas.cpp
@@ -175,7 +175,7 @@ static void CompactIndexPragma(ClientContext &context, const FunctionParameters 
 	bool found_index = false;
 
 	auto &table_info = *storage.GetDataTableInfo();
-	table_info.GetIndexes().BindAndScan<HNSWIndex>(context, table_info,  [&](HNSWIndex &hnsw_index) {
+	table_info.GetIndexes().BindAndScan<HNSWIndex>(context, table_info, [&](HNSWIndex &hnsw_index) {
 		if (index_entry.name == index_name) {
 			hnsw_index.Compact();
 			found_index = true;

--- a/src/hnsw/hnsw_index_scan.cpp
+++ b/src/hnsw/hnsw_index_scan.cpp
@@ -60,7 +60,8 @@ static unique_ptr<GlobalTableFunctionState> HNSWIndexScanInitGlobal(ClientContex
 	local_storage.InitializeScan(bind_data.table.GetStorage(), result->local_storage_state.local_state, input.filters);
 
 	// Initialize the scan state for the index
-	result->index_state = bind_data.index.Cast<HNSWIndex>().InitializeScan(bind_data.query.get(), bind_data.limit, context);
+	result->index_state =
+	    bind_data.index.Cast<HNSWIndex>().InitializeScan(bind_data.query.get(), bind_data.limit, context);
 
 	return std::move(result);
 }

--- a/src/include/hnsw/hnsw_index.hpp
+++ b/src/include/hnsw/hnsw_index.hpp
@@ -94,6 +94,9 @@ public:
 		return "Constraint violation in HNSW index";
 	}
 
+	void SetDirty() { is_dirty = true; }
+	void SyncSize() { index_size = index.size(); }
+
 private:
 	bool is_dirty = false;
 	StorageLock rwlock;

--- a/src/include/hnsw/hnsw_index.hpp
+++ b/src/include/hnsw/hnsw_index.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-
 #include "duckdb/execution/index/bound_index.hpp"
 #include "duckdb/execution/index/index_pointer.hpp"
 #include "duckdb/execution/index/fixed_size_allocator.hpp"
@@ -94,8 +93,12 @@ public:
 		return "Constraint violation in HNSW index";
 	}
 
-	void SetDirty() { is_dirty = true; }
-	void SyncSize() { index_size = index.size(); }
+	void SetDirty() {
+		is_dirty = true;
+	}
+	void SyncSize() {
+		index_size = index.size();
+	}
 
 private:
 	bool is_dirty = false;

--- a/src/vss_extension.cpp
+++ b/src/vss_extension.cpp
@@ -12,7 +12,6 @@
 
 namespace duckdb {
 
-
 static void LoadInternal(DatabaseInstance &instance) {
 	// Register the HNSW index module
 	HNSWModule::Register(instance);


### PR DESCRIPTION
Instead of constructing indexes during the sinking into the create index operator, we now buffer all input and then spawn tasks equal to the amount of threads that construct the index with all the data available in parallel. This means we now parallelize over vectors instead of row groups regardless of how much data we receive, and don't need to resize/reallocate the index multiple times (with extra locking) during construction.

On my machine this gives me an almost 10x performance increase. But there's still a bunch more small optimizations we can do.