### PR TITLE
Add vector join table macros

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   duckdb-stable-build:
     name: Build extension binaries
-    uses: ./.github/workflows/_extension_distribution.yml
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       duckdb_version: main
       extension_name: vss

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,12 @@ set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 
 project(${TARGET_NAME})
 
-option(USE_SIMSIMD "Use SIMSIMD library to sacrifice portability for vectorized search" OFF)
+option(USE_SIMSIMD
+       "Use SIMSIMD library to sacrifice portability for vectorized search" OFF)
 if(USE_SIMSIMD)
-    add_definitions(-DDUCKDB_USEARCH_USE_SIMSIMD=1)
+  add_definitions(-DDUCKDB_USEARCH_USE_SIMSIMD=1)
 else()
-    add_definitions(-DDUCKDB_USEARCH_USE_SIMSIMD=0)
+  add_definitions(-DDUCKDB_USEARCH_USE_SIMSIMD=0)
 endif()
 
 include_directories(src/include)

--- a/src/hnsw/CMakeLists.txt
+++ b/src/hnsw/CMakeLists.txt
@@ -3,6 +3,7 @@ set(EXTENSION_SOURCES
         ${EXTENSION_SOURCES}
         ${CMAKE_CURRENT_SOURCE_DIR}/hnsw_index.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/hnsw_index_logical_create.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/hnsw_index_macros.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/hnsw_index_physical_create.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/hnsw_index_pragmas.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/hnsw_index_scan.cpp

--- a/src/hnsw/hnsw_index.cpp
+++ b/src/hnsw/hnsw_index.cpp
@@ -14,7 +14,7 @@ namespace duckdb {
 
 class LinkedBlock {
 public:
-	static constexpr const idx_t BLOCK_SIZE = Storage::BLOCK_SIZE - sizeof(validity_t);
+	static constexpr const idx_t BLOCK_SIZE = Storage::DEFAULT_BLOCK_SIZE - sizeof(validity_t);
 	static constexpr const idx_t BLOCK_DATA_SIZE = BLOCK_SIZE - sizeof(IndexPointer);
 	static_assert(BLOCK_SIZE > sizeof(IndexPointer), "Block size must be larger than the size of an IndexPointer");
 

--- a/src/hnsw/hnsw_index_macros.cpp
+++ b/src/hnsw/hnsw_index_macros.cpp
@@ -78,7 +78,7 @@ FROM
 // Register
 //-------------------------------------------------------------------------
 static void RegisterTableMacro(DatabaseInstance &db, const string &name, const string &query,
-	const vector<string> &params, const child_list_t<Value> &named_params) {
+                               const vector<string> &params, const child_list_t<Value> &named_params) {
 
 	Parser parser;
 	parser.ParseQuery(query);
@@ -106,14 +106,11 @@ static void RegisterTableMacro(DatabaseInstance &db, const string &name, const s
 
 void HNSWModule::RegisterMacros(DatabaseInstance &db) {
 
-	RegisterTableMacro(db, "vss_join", VSS_JOIN_MACRO,
-		{"left_table", "right_table", "left_col", "right_col", "k"},
-		{{"metric", Value("l2sq")}});
+	RegisterTableMacro(db, "vss_join", VSS_JOIN_MACRO, {"left_table", "right_table", "left_col", "right_col", "k"},
+	                   {{"metric", Value("l2sq")}});
 
-	RegisterTableMacro(db, "vss_match", VSS_MATCH_MACRO,
-		{"right_table", "left_col", "right_col", "k"},
-		{{"metric", Value("l2sq")}});
-
+	RegisterTableMacro(db, "vss_match", VSS_MATCH_MACRO, {"right_table", "left_col", "right_col", "k"},
+	                   {{"metric", Value("l2sq")}});
 }
 
 } // namespace duckdb

--- a/src/hnsw/hnsw_index_macros.cpp
+++ b/src/hnsw/hnsw_index_macros.cpp
@@ -1,0 +1,119 @@
+#include "duckdb/function/table_macro_function.hpp"
+#include "duckdb/main/extension_util.hpp"
+#include "duckdb/optimizer/matcher/expression_matcher.hpp"
+#include "hnsw/hnsw.hpp"
+#include "hnsw/hnsw_index.hpp"
+#include "duckdb/parser/parser.hpp"
+
+namespace duckdb {
+
+static constexpr auto VSS_JOIN_MACRO = R"(
+SELECT
+	score,
+	left_tbl,
+	right_tbl,
+FROM
+	(SELECT * FROM query_table(left_table::VARCHAR)) as left_tbl,
+	(
+		SELECT
+			struct_pack(*columns([x for x in (matches.*) if x != 'score'])) as right_tbl,
+			matches.score as score
+		FROM (
+			SELECT (
+				unnest(
+					CASE WHEN metric = 'l2sq' OR metric = 'l2'
+						THEN min_by(tbl, tbl.score, k)
+						ELSE max_by(tbl, tbl.score, k)
+					END,
+					max_depth := 2
+				)
+			) as result
+			FROM (
+				SELECT
+				*,
+				CASE
+					WHEN metric = 'l2sq' OR metric = 'l2'
+					THEN array_distance(left_col, right_col)
+					WHEN metric = 'cosine' OR metric = 'cos'
+					THEN array_cosine_similarity(left_col, right_col)
+					WHEN metric = 'ip'
+					THEN array_inner_product(left_col, right_col)
+					ELSE error('Unknown metric')
+				END as score,
+				FROM query_table(right_table::VARCHAR)
+			) as tbl
+		) as matches
+	)
+)";
+
+static constexpr auto VSS_MATCH_MACRO = R"(
+SELECT
+	right_tbl as matches,
+FROM
+	(
+		SELECT (
+			CASE WHEN metric = 'l2sq' OR metric = 'l2'
+				THEN min_by({'score': score, 'row': t}, score, k)
+				ELSE max_by({'score': score, 'row': t}, score, k)
+			END
+		) as right_tbl
+		FROM (
+			SELECT
+			CASE
+				WHEN metric = 'l2sq' OR metric = 'l2'
+				THEN array_distance(left_col, right_col)
+				WHEN metric = 'cosine' OR metric = 'cos'
+				THEN array_cosine_similarity(left_col, right_col)
+				WHEN metric = 'ip'
+				THEN array_inner_product(left_col, right_col)
+				ELSE error('Unknown metric')
+			END as score,
+			tbl as t,
+			FROM (SELECT * FROM query_table(right_table::VARCHAR)) as tbl
+		)
+	)
+)";
+
+//-------------------------------------------------------------------------
+// Register
+//-------------------------------------------------------------------------
+static void RegisterTableMacro(DatabaseInstance &db, const string &name, const string &query,
+	const vector<string> &params, const child_list_t<Value> &named_params) {
+
+	Parser parser;
+	parser.ParseQuery(query);
+	const auto &stmt = parser.statements.back();
+	auto &node = stmt->Cast<SelectStatement>().node;
+
+	auto func = make_uniq<TableMacroFunction>(std::move(node));
+	for (auto &param : params) {
+		func->parameters.push_back(make_uniq<ColumnRefExpression>(param));
+	}
+
+	for (auto &param : named_params) {
+		func->default_parameters[param.first] = make_uniq<ConstantExpression>(param.second);
+	}
+
+	CreateMacroInfo info(CatalogType::TABLE_MACRO_ENTRY);
+	info.schema = DEFAULT_SCHEMA;
+	info.name = name;
+	info.temporary = true;
+	info.internal = true;
+	info.macros.push_back(std::move(func));
+
+	ExtensionUtil::RegisterFunction(db, info);
+}
+
+void HNSWModule::RegisterMacros(DatabaseInstance &db) {
+
+	RegisterTableMacro(db, "vss_join", VSS_JOIN_MACRO,
+		{"left_table", "right_table", "left_col", "right_col", "k"},
+		{{"metric", Value("l2sq")}});
+
+	RegisterTableMacro(db, "vss_match", VSS_MATCH_MACRO,
+		{"right_table", "left_col", "right_col", "k"},
+		{{"metric", Value("l2sq")}});
+
+}
+
+} // namespace duckdb

--- a/src/hnsw/hnsw_index_physical_create.cpp
+++ b/src/hnsw/hnsw_index_physical_create.cpp
@@ -131,7 +131,8 @@ class HNSWIndexConstructTask final : public ExecutorTask {
 public:
 	HNSWIndexConstructTask(shared_ptr<Event> event_p, ClientContext &context, CreateHNSWIndexGlobalState &gstate_p,
 	                       size_t thread_id_p, const PhysicalCreateHNSWIndex &op_p)
-	    : ExecutorTask(context, std::move(event_p), op_p), gstate(gstate_p), thread_id(thread_id_p), local_scan_state() {
+	    : ExecutorTask(context, std::move(event_p), op_p), gstate(gstate_p), thread_id(thread_id_p),
+	      local_scan_state() {
 		// Initialize the scan chunk
 		gstate.collection->InitializeScanChunk(scan_chunk);
 	}
@@ -209,9 +210,11 @@ private:
 
 class HNSWIndexConstructionEvent final : public BasePipelineEvent {
 public:
-	HNSWIndexConstructionEvent(const PhysicalCreateHNSWIndex &op_p, CreateHNSWIndexGlobalState &gstate_p, Pipeline &pipeline_p, CreateIndexInfo &info_p,
-	                           const vector<column_t> &storage_ids_p, DuckTableEntry &table_p)
-	    : BasePipelineEvent(pipeline_p), op(op_p), gstate(gstate_p), info(info_p), storage_ids(storage_ids_p), table(table_p) {
+	HNSWIndexConstructionEvent(const PhysicalCreateHNSWIndex &op_p, CreateHNSWIndexGlobalState &gstate_p,
+	                           Pipeline &pipeline_p, CreateIndexInfo &info_p, const vector<column_t> &storage_ids_p,
+	                           DuckTableEntry &table_p)
+	    : BasePipelineEvent(pipeline_p), op(op_p), gstate(gstate_p), info(info_p), storage_ids(storage_ids_p),
+	      table(table_p) {
 	}
 
 	const PhysicalCreateHNSWIndex &op;

--- a/src/hnsw/hnsw_index_physical_create.cpp
+++ b/src/hnsw/hnsw_index_physical_create.cpp
@@ -130,8 +130,8 @@ SinkCombineResultType PhysicalCreateHNSWIndex::Combine(ExecutionContext &context
 class HNSWIndexConstructTask final : public ExecutorTask {
 public:
 	HNSWIndexConstructTask(shared_ptr<Event> event_p, ClientContext &context, CreateHNSWIndexGlobalState &gstate_p,
-	                       size_t thread_id_p)
-	    : ExecutorTask(context, std::move(event_p)), gstate(gstate_p), thread_id(thread_id_p), local_scan_state() {
+	                       size_t thread_id_p, const PhysicalCreateHNSWIndex &op_p)
+	    : ExecutorTask(context, std::move(event_p), op_p), gstate(gstate_p), thread_id(thread_id_p), local_scan_state() {
 		// Initialize the scan chunk
 		gstate.collection->InitializeScanChunk(scan_chunk);
 	}
@@ -209,11 +209,12 @@ private:
 
 class HNSWIndexConstructionEvent final : public BasePipelineEvent {
 public:
-	HNSWIndexConstructionEvent(CreateHNSWIndexGlobalState &gstate_p, Pipeline &pipeline_p, CreateIndexInfo &info_p,
+	HNSWIndexConstructionEvent(const PhysicalCreateHNSWIndex &op_p, CreateHNSWIndexGlobalState &gstate_p, Pipeline &pipeline_p, CreateIndexInfo &info_p,
 	                           const vector<column_t> &storage_ids_p, DuckTableEntry &table_p)
-	    : BasePipelineEvent(pipeline_p), gstate(gstate_p), info(info_p), storage_ids(storage_ids_p), table(table_p) {
+	    : BasePipelineEvent(pipeline_p), op(op_p), gstate(gstate_p), info(info_p), storage_ids(storage_ids_p), table(table_p) {
 	}
 
+	const PhysicalCreateHNSWIndex &op;
 	CreateHNSWIndexGlobalState &gstate;
 	CreateIndexInfo &info;
 	const vector<column_t> &storage_ids;
@@ -229,7 +230,7 @@ public:
 
 		vector<shared_ptr<Task>> construct_tasks;
 		for (size_t tnum = 0; tnum < num_threads; tnum++) {
-			construct_tasks.push_back(make_uniq<HNSWIndexConstructTask>(shared_from_this(), context, gstate, tnum));
+			construct_tasks.push_back(make_uniq<HNSWIndexConstructTask>(shared_from_this(), context, gstate, tnum, op));
 		}
 		SetTasks(std::move(construct_tasks));
 	}
@@ -295,7 +296,7 @@ SinkFinalizeType PhysicalCreateHNSWIndex::Finalize(Pipeline &pipeline, Event &ev
 	collection->InitializeScan(gstate.scan_state, ColumnDataScanProperties::ALLOW_ZERO_COPY);
 
 	// Create a new event that will construct the index
-	auto new_event = make_shared_ptr<HNSWIndexConstructionEvent>(gstate, pipeline, *info, storage_ids, table);
+	auto new_event = make_shared_ptr<HNSWIndexConstructionEvent>(*this, gstate, pipeline, *info, storage_ids, table);
 	event.InsertEvent(std::move(new_event));
 
 	return SinkFinalizeType::READY;

--- a/src/include/hnsw/hnsw.hpp
+++ b/src/include/hnsw/hnsw.hpp
@@ -12,6 +12,7 @@ public:
 		RegisterIndexPragmas(db);
 		RegisterPlanIndexScan(db);
 		RegisterPlanIndexCreate(db);
+		RegisterMacros(db);
 	}
 
 private:
@@ -20,6 +21,7 @@ private:
 	static void RegisterIndexPragmas(DatabaseInstance &db);
 	static void RegisterPlanIndexScan(DatabaseInstance &db);
 	static void RegisterPlanIndexCreate(DatabaseInstance &db);
+	static void RegisterMacros(DatabaseInstance &db);
 };
 
 } // namespace duckdb

--- a/test/sql/hnsw/hnsw_join_macro.test
+++ b/test/sql/hnsw/hnsw_join_macro.test
@@ -12,7 +12,12 @@ CREATE TABLE s(s_vec FLOAT[3]);
 statement ok
 INSERT INTO s VALUES ([5,5,5]), ([1,1,1]);
 
-query III
+query I
+SELECT bool_and(score <= 1.0) FROM vss_join(s, t1, s_vec, vec, 3) as res;
+----
+true
+
+query I
 SELECT len(matches) = 3 FROM s, vss_match(t1, s_vec, vec, 3) as res;
 ----
 true

--- a/test/sql/hnsw/hnsw_join_macro.test
+++ b/test/sql/hnsw/hnsw_join_macro.test
@@ -1,0 +1,19 @@
+require vss
+
+statement ok
+CREATE TABLE t1 (id int, vec FLOAT[3]);
+
+statement ok
+INSERT INTO t1 SELECT row_number() over (), array_value(a,b,c) FROM range(1,10) ra(a), range(1,10) rb(b), range(1,10) rc(c);
+
+statement ok
+CREATE TABLE s(s_vec FLOAT[3]);
+
+statement ok
+INSERT INTO s VALUES ([5,5,5]), ([1,1,1]);
+
+query III
+SELECT len(matches) = 3 FROM s, vss_match(t1, s_vec, vec, 3) as res;
+----
+true
+true


### PR DESCRIPTION
Now that https://github.com/duckdb/duckdb/pull/12834 and https://github.com/duckdb/duckdb/pull/13342 have landed in core DuckDB we can make vector search a bit easier.
This PR adds two table functions, implemented as table macros, to enable easy fuzzy joining of two vector datasets: 
- `vss_join(left_table, right_table, left_col, right_col, k, metric := 'l2sq)` 

  Joins the `left_table` and `right_table` by matching up to `k` vectors in `right_col` for each vector in `left_col`, using the metric `metric` (by default `l2sq`)
  
  
-  `vss_match(right_table, left_col, right_col, k, metric := 'l2sq')`
  
  Returns up to `k` rows matching `right_col` in `right_table` for each input vector in `left_col`. Since you don't pass in a `left_table` to this function, you can pass in any scalar argument as `left_col` which allows you to use this function both in a lateral join or with a constant.
  
  
Examples:
```sql
CREATE TABLE source (name VARCHAR, s_vec FLOAT[3]);
INSERT INTO source VALUES ('alice', [5,5,5]::FLOAT[3]), ('bob', [100,120,90]::FLOAT[3]);

CREATE TABLE dest (id INTEGER, d_vec FLOAT[3]);
INSERT INTO dest SELECT row_number() over (), array_value(a,b,c) FROM range(1,10) ra(a), range(1,10) rb(b), range(1,10) rc(c);

-- Join the two tables
SELECT * FROM vss_join(source, dest, s_vec, d_vec, 3);
----
┌───────────┬──────────────────────────────────────────────┬───────────────────────────────────────┐
│   score   │                   left_tbl                   │               right_tbl               │
│   float   │    struct("name" varchar, s_vec float[3])    │  struct(id integer, d_vec float[3])   │
├───────────┼──────────────────────────────────────────────┼───────────────────────────────────────┤
│ 164.81201 │ {'name': bob, 's_vec': [100.0, 120.0, 90.0]} │ {'id': 729, 'd_vec': [9.0, 9.0, 9.0]} │
│ 165.30577 │ {'name': bob, 's_vec': [100.0, 120.0, 90.0]} │ {'id': 648, 'd_vec': [9.0, 9.0, 8.0]} │
│ 165.36626 │ {'name': bob, 's_vec': [100.0, 120.0, 90.0]} │ {'id': 720, 'd_vec': [8.0, 9.0, 9.0]} │
│       0.0 │ {'name': alice, 's_vec': [5.0, 5.0, 5.0]}    │ {'id': 365, 'd_vec': [5.0, 5.0, 5.0]} │
│       1.0 │ {'name': alice, 's_vec': [5.0, 5.0, 5.0]}    │ {'id': 364, 'd_vec': [5.0, 4.0, 5.0]} │
│       1.0 │ {'name': alice, 's_vec': [5.0, 5.0, 5.0]}    │ {'id': 356, 'd_vec': [4.0, 5.0, 5.0]} │
└───────────┴──────────────────────────────────────────────┴───────────────────────────────────────┘

-- Rank the source table rows against a constant vector
SELECT * FROM vss_match(source, [10, 10, 10]::FLOAT[3], s_vec, 5);
----
┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                                                       matches                                                                       │
│                                         struct(score float, "row" struct("name" varchar, s_vec float[3]))[]                                         │
├─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ [{'score': 8.6602545, 'row': {'name': alice, 's_vec': [5.0, 5.0, 5.0]}}, {'score': 163.09506, 'row': {'name': bob, 's_vec': [100.0, 120.0, 90.0]}}] │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘


-- Perform a lateral join
SELECT * FROM source, vss_match(dest, s_vec, d_vec, 2);
----
┌─────────┬──────────────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│  name   │        s_vec         │                                                                 matches                                                                  │
│ varchar │       float[3]       │                                     struct(score float, "row" struct(id integer, d_vec float[3]))[]                                      │
├─────────┼──────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ bob     │ [100.0, 120.0, 90.0] │ [{'score': 164.81201, 'row': {'id': 729, 'd_vec': [9.0, 9.0, 9.0]}}, {'score': 165.30577, 'row': {'id': 648, 'd_vec': [9.0, 9.0, 8.0]}}] │
│ alice   │ [5.0, 5.0, 5.0]      │ [{'score': 0.0, 'row': {'id': 365, 'd_vec': [5.0, 5.0, 5.0]}}, {'score': 1.0, 'row': {'id': 356, 'd_vec': [4.0, 5.0, 5.0]}}]             │
└─────────┴──────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```