### PR TITLE
Optimize lateral VSS joins using HNSW index

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -28,6 +28,7 @@ jobs:
     with:
       duckdb_version: main
       extension_name: vss
+      ci_tools_version: main
 
   duckdb-stable-deploy:
     name: Deploy extension binaries

--- a/src/hnsw/CMakeLists.txt
+++ b/src/hnsw/CMakeLists.txt
@@ -9,8 +9,9 @@ set(EXTENSION_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/hnsw_index_scan.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/hnsw_plan_index_create.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/hnsw_topk_operator.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/hnsw_optimize_topk.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/hnsw_optimize_expr.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/hnsw_optimize_join.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/hnsw_optimize_topk.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/hnsw_optimize_scan.cpp
         PARENT_SCOPE
 )

--- a/src/hnsw/hnsw_index.cpp
+++ b/src/hnsw/hnsw_index.cpp
@@ -35,7 +35,7 @@ private:
 
 public:
 	LinkedBlockReader(FixedSizeAllocator &allocator, IndexPointer root_pointer)
-		: allocator(allocator), root_pointer(root_pointer), current_pointer(root_pointer), position_in_block(0) {
+	    : allocator(allocator), root_pointer(root_pointer), current_pointer(root_pointer), position_in_block(0) {
 	}
 
 	void Reset() {
@@ -77,7 +77,7 @@ private:
 
 public:
 	LinkedBlockWriter(FixedSizeAllocator &allocator, IndexPointer root_pointer)
-		: allocator(allocator), root_pointer(root_pointer), current_pointer(root_pointer), position_in_block(0) {
+	    : allocator(allocator), root_pointer(root_pointer), current_pointer(root_pointer), position_in_block(0) {
 	}
 
 	void ClearCurrentBlock() {
@@ -119,10 +119,10 @@ public:
 
 // Constructor
 HNSWIndex::HNSWIndex(const string &name, IndexConstraintType index_constraint_type, const vector<column_t> &column_ids,
-					 TableIOManager &table_io_manager, const vector<unique_ptr<Expression>> &unbound_expressions,
-					 AttachedDatabase &db, const case_insensitive_map_t<Value> &options, const IndexStorageInfo &info,
-					 idx_t estimated_cardinality)
-	: BoundIndex(name, TYPE_NAME, index_constraint_type, column_ids, table_io_manager, unbound_expressions, db) {
+                     TableIOManager &table_io_manager, const vector<unique_ptr<Expression>> &unbound_expressions,
+                     AttachedDatabase &db, const case_insensitive_map_t<Value> &options, const IndexStorageInfo &info,
+                     idx_t estimated_cardinality)
+    : BoundIndex(name, TYPE_NAME, index_constraint_type, column_ids, table_io_manager, unbound_expressions, db) {
 
 	if (index_constraint_type != IndexConstraintType::NONE) {
 		throw NotImplementedException("HNSW indexes do not support unique or primary key constraints");
@@ -202,13 +202,12 @@ HNSWIndex::HNSWIndex(const string &name, IndexConstraintType index_constraint_ty
 		if (!info.allocator_infos[0].buffer_ids.empty()) {
 			LinkedBlockReader reader(*linked_block_allocator, root_block_ptr);
 			index.load_from_stream(
-				[&](void *data, size_t size) { return size == reader.ReadData(static_cast<data_ptr_t>(data), size); });
+			    [&](void *data, size_t size) { return size == reader.ReadData(static_cast<data_ptr_t>(data), size); });
 		}
 	} else {
 		index.reserve(MinValue(static_cast<idx_t>(32), estimated_cardinality));
 	}
 	index_size = index.size();
-
 
 	function_matcher = MakeFunctionMatcher();
 }
@@ -231,31 +230,31 @@ string HNSWIndex::GetMetric() const {
 }
 
 const case_insensitive_map_t<unum::usearch::metric_kind_t> HNSWIndex::METRIC_KIND_MAP = {
-	{"l2sq", unum::usearch::metric_kind_t::l2sq_k},
-	{"cosine", unum::usearch::metric_kind_t::cos_k},
-	{"ip", unum::usearch::metric_kind_t::ip_k},
-	/* TODO: Add the rest of these later
-	{"divergence", unum::usearch::metric_kind_t::divergence_k},
-	{"hamming", unum::usearch::metric_kind_t::hamming_k},
-	{"jaccard", unum::usearch::metric_kind_t::jaccard_k},
-	{"haversine", unum::usearch::metric_kind_t::haversine_k},
-	{"pearson", unum::usearch::metric_kind_t::pearson_k},
-	{"sorensen", unum::usearch::metric_kind_t::sorensen_k},
-	{"tanimoto", unum::usearch::metric_kind_t::tanimoto_k}
-	 */
+    {"l2sq", unum::usearch::metric_kind_t::l2sq_k},
+    {"cosine", unum::usearch::metric_kind_t::cos_k},
+    {"ip", unum::usearch::metric_kind_t::ip_k},
+    /* TODO: Add the rest of these later
+    {"divergence", unum::usearch::metric_kind_t::divergence_k},
+    {"hamming", unum::usearch::metric_kind_t::hamming_k},
+    {"jaccard", unum::usearch::metric_kind_t::jaccard_k},
+    {"haversine", unum::usearch::metric_kind_t::haversine_k},
+    {"pearson", unum::usearch::metric_kind_t::pearson_k},
+    {"sorensen", unum::usearch::metric_kind_t::sorensen_k},
+    {"tanimoto", unum::usearch::metric_kind_t::tanimoto_k}
+     */
 };
 
 const unordered_map<uint8_t, unum::usearch::scalar_kind_t> HNSWIndex::SCALAR_KIND_MAP = {
-	{static_cast<uint8_t>(LogicalTypeId::FLOAT), unum::usearch::scalar_kind_t::f32_k},
-	{static_cast<uint8_t>(LogicalTypeId::DOUBLE), unum::usearch::scalar_kind_t::f64_k},
-	{static_cast<uint8_t>(LogicalTypeId::TINYINT), unum::usearch::scalar_kind_t::i8_k},
-	{static_cast<uint8_t>(LogicalTypeId::SMALLINT), unum::usearch::scalar_kind_t::i16_k},
-	{static_cast<uint8_t>(LogicalTypeId::INTEGER), unum::usearch::scalar_kind_t::i32_k},
-	{static_cast<uint8_t>(LogicalTypeId::BIGINT), unum::usearch::scalar_kind_t::i64_k},
-	{static_cast<uint8_t>(LogicalTypeId::UTINYINT), unum::usearch::scalar_kind_t::u8_k},
-	{static_cast<uint8_t>(LogicalTypeId::USMALLINT), unum::usearch::scalar_kind_t::u16_k},
-	{static_cast<uint8_t>(LogicalTypeId::UINTEGER), unum::usearch::scalar_kind_t::u32_k},
-	{static_cast<uint8_t>(LogicalTypeId::UBIGINT), unum::usearch::scalar_kind_t::u64_k}};
+    {static_cast<uint8_t>(LogicalTypeId::FLOAT), unum::usearch::scalar_kind_t::f32_k},
+    {static_cast<uint8_t>(LogicalTypeId::DOUBLE), unum::usearch::scalar_kind_t::f64_k},
+    {static_cast<uint8_t>(LogicalTypeId::TINYINT), unum::usearch::scalar_kind_t::i8_k},
+    {static_cast<uint8_t>(LogicalTypeId::SMALLINT), unum::usearch::scalar_kind_t::i16_k},
+    {static_cast<uint8_t>(LogicalTypeId::INTEGER), unum::usearch::scalar_kind_t::i32_k},
+    {static_cast<uint8_t>(LogicalTypeId::BIGINT), unum::usearch::scalar_kind_t::i64_k},
+    {static_cast<uint8_t>(LogicalTypeId::UTINYINT), unum::usearch::scalar_kind_t::u8_k},
+    {static_cast<uint8_t>(LogicalTypeId::USMALLINT), unum::usearch::scalar_kind_t::u16_k},
+    {static_cast<uint8_t>(LogicalTypeId::UINTEGER), unum::usearch::scalar_kind_t::u32_k},
+    {static_cast<uint8_t>(LogicalTypeId::UBIGINT), unum::usearch::scalar_kind_t::u64_k}};
 
 unique_ptr<HNSWIndexStats> HNSWIndex::GetStats() {
 	auto lock = rwlock.GetExclusiveLock();
@@ -374,7 +373,6 @@ void HNSWIndex::ResetMultiScan(IndexScanState &state) {
 	auto &scan_state = state.Cast<MultiScanState>();
 	scan_state.row_ids.clear();
 }
-
 
 void HNSWIndex::CommitDrop(IndexLock &index_lock) {
 	// Acquire an exclusive lock to drop the index
@@ -573,9 +571,9 @@ void HNSWIndex::VerifyAllocations(IndexLock &state) {
 // Can rewrite index expression?
 //------------------------------------------------------------------------------
 static void TryBindIndexExpressionInternal(Expression &expr, idx_t table_idx, const vector<column_t> &index_columns,
-	const vector<column_t> &table_columns, bool &success, bool &found) {
+                                           const vector<column_t> &table_columns, bool &success, bool &found) {
 
-	if(expr.type == ExpressionType::BOUND_COLUMN_REF) {
+	if (expr.type == ExpressionType::BOUND_COLUMN_REF) {
 		found = true;
 		auto &ref = expr.Cast<BoundColumnRefExpression>();
 
@@ -583,8 +581,8 @@ static void TryBindIndexExpressionInternal(Expression &expr, idx_t table_idx, co
 		ref.binding.table_index = table_idx;
 
 		const auto referenced_column = index_columns[ref.binding.column_index];
-		for(idx_t i = 0; i < table_columns.size(); i++) {
-			if(table_columns[i] == referenced_column) {
+		for (idx_t i = 0; i < table_columns.size(); i++) {
+			if (table_columns[i] == referenced_column) {
 				ref.binding.column_index = i;
 				return;
 			}
@@ -609,31 +607,32 @@ bool HNSWIndex::TryBindIndexExpression(LogicalGet &get, unique_ptr<Expression> &
 
 	TryBindIndexExpressionInternal(expr, get.table_index, index_columns, table_columns, success, found);
 
-	if(success && found) {
+	if (success && found) {
 		result = std::move(expr_ptr);
 		return true;
 	}
 	return false;
 }
 
-bool HNSWIndex::TryMatchDistanceFunction(const unique_ptr<Expression>& expr, vector<reference<Expression>> &bindings) const {
+bool HNSWIndex::TryMatchDistanceFunction(const unique_ptr<Expression> &expr,
+                                         vector<reference<Expression>> &bindings) const {
 	return function_matcher->Match(*expr, bindings);
 }
 
 unique_ptr<ExpressionMatcher> HNSWIndex::MakeFunctionMatcher() const {
 	unordered_set<string> distance_functions;
-	switch(index.metric().metric_kind()) {
-		case unum::usearch::metric_kind_t::l2sq_k:
-			distance_functions = { "array_distance", "<->" };
-			break;
-		case unum::usearch::metric_kind_t::cos_k:
-			distance_functions = { "array_cosine_distance", "<=>" };
-			break;
-		case unum::usearch::metric_kind_t::ip_k:
-			distance_functions = { "array_negative_inner_product", "<#>" };
-			break;
-		default:
-			throw NotImplementedException("Unknown metric kind");
+	switch (index.metric().metric_kind()) {
+	case unum::usearch::metric_kind_t::l2sq_k:
+		distance_functions = {"array_distance", "<->"};
+		break;
+	case unum::usearch::metric_kind_t::cos_k:
+		distance_functions = {"array_cosine_distance", "<=>"};
+		break;
+	case unum::usearch::metric_kind_t::ip_k:
+		distance_functions = {"array_negative_inner_product", "<#>"};
+		break;
+	default:
+		throw NotImplementedException("Unknown metric kind");
 	}
 
 	auto matcher = make_uniq<FunctionExpressionMatcher>();

--- a/src/hnsw/hnsw_optimize_join.cpp
+++ b/src/hnsw/hnsw_optimize_join.cpp
@@ -2,68 +2,71 @@
 #include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/execution/column_binding_resolver.hpp"
+#include "duckdb/optimizer/column_binding_replacer.hpp"
 #include "duckdb/optimizer/matcher/expression_matcher.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
-#include "duckdb/planner/expression/bound_aggregate_expression.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
-#include "duckdb/planner/expression_iterator.hpp"
+#include "duckdb/planner/expression/bound_window_expression.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
 #include "duckdb/planner/operator/logical_cross_product.hpp"
 #include "duckdb/planner/operator/logical_delim_get.hpp"
 #include "duckdb/planner/operator/logical_extension_operator.hpp"
+#include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/planner/operator/logical_join.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
-#include "duckdb/optimizer/column_binding_replacer.hpp"
+#include "duckdb/planner/operator/logical_window.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
-
 #include "hnsw/hnsw.hpp"
 #include "hnsw/hnsw_index.hpp"
-#include "hnsw/hnsw_index_scan.hpp"
 
+#include <duckdb/planner/expression_iterator.hpp>
 
 namespace duckdb {
 
 //------------------------------------------------------------------------------
-// Physical operator
+// Physical Operator
 //------------------------------------------------------------------------------
+
 class PhysicalHNSWIndexJoin final : public PhysicalOperator {
 public:
 	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::EXTENSION;
-public:
-	// TODO: Pass estimated cardinality
-	PhysicalHNSWIndexJoin(vector<LogicalType> &types, DuckTableEntry &table_p, HNSWIndex &hnsw_index_p, idx_t limit_p,
-		const vector<column_t>& table_column_ids_p, const vector<LogicalType> &table_types_p)
-		: PhysicalOperator(PhysicalOperatorType::EXTENSION, types, 0), table(table_p),
-	hnsw_index(hnsw_index_p), limit(limit_p), logical_column_ids(table_column_ids_p), table_types(table_types_p) {
-	}
 
+	PhysicalHNSWIndexJoin(const vector<LogicalType> &types_p, const idx_t estimated_cardinality, DuckTableEntry &table_p, HNSWIndex &hnsw_index_p, const idx_t limit_p)
+		: PhysicalOperator(TYPE, types_p, estimated_cardinality), table(table_p), hnsw_index(hnsw_index_p), limit(limit_p) {
+	}
 public:
-	string GetName() const override { return "HNSW_INDEX_JOIN"; }
-	bool ParallelOperator() const override { return false; }
+	string GetName() const override;
+	bool ParallelOperator() const override;
 	unique_ptr<OperatorState> GetOperatorState(ExecutionContext &context) const override;
 	OperatorResultType Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
 						   GlobalOperatorState &gstate, OperatorState &state) const override;
+
 public:
 	DuckTableEntry &table;
 	HNSWIndex &hnsw_index;
-
-	// The projection expressions (the struct pack of the rows from the right table)
-	unique_ptr<Expression> proj_expression;
-
-	// The matching vector on the lhs side
-	unique_ptr<Expression> group_expression;
-
 	idx_t limit;
-	vector<column_t> logical_column_ids;
-	vector<LogicalType> table_types;
+
+	vector<column_t> lhs_column_ids;
+	vector<idx_t> lhs_projection_ids;
+	idx_t lhs_vector_column;
+	idx_t rhs_vector_column;
 };
 
-class HNSWIndexJoinState : public OperatorState {
-public:
-	explicit HNSWIndexJoinState(ClientContext &context) : executor(context) { }
+string PhysicalHNSWIndexJoin::GetName() const {
+	return "HNSW_INDEX_JOIN";
+}
 
+bool PhysicalHNSWIndexJoin::ParallelOperator() const {
+	return false;
+}
+
+// TODO: Assert at most k = SVS
+class HNSWIndexJoinState final : public OperatorState {
+public:
 	idx_t input_idx = 0;
 
 	ColumnFetchState fetch_state;
@@ -72,24 +75,17 @@ public:
 
 	// Index scan state
 	unique_ptr<IndexScanState> index_state;
-	Vector row_ids = Vector(LogicalType::ROW_TYPE);
-
-
 	SelectionVector match_sel;
-	DataChunk table_chunk;
-	//DataChunk proj_chunk;
-
-	ExpressionExecutor executor;
 };
 
 unique_ptr<OperatorState> PhysicalHNSWIndexJoin::GetOperatorState(ExecutionContext &context) const {
-	auto result = make_uniq<HNSWIndexJoinState>(context.client);
+	auto result = make_uniq<HNSWIndexJoinState>();
 
 	auto &local_storage = LocalStorage::Get(context.client, table.catalog);
-	result->phyiscal_column_ids.reserve(logical_column_ids.size());
+	result->phyiscal_column_ids.reserve(lhs_column_ids.size());
 
 	// Figure out the storage column ids from the projection expression
-	for(auto &id : logical_column_ids) {
+	for(auto &id : lhs_column_ids) {
 		storage_t col_id = id;
 		if(id != DConstants::INVALID_INDEX) {
 			col_id = table.GetColumn(LogicalIndex(id)).StorageOid();
@@ -97,78 +93,68 @@ unique_ptr<OperatorState> PhysicalHNSWIndexJoin::GetOperatorState(ExecutionConte
 		result->phyiscal_column_ids.push_back(col_id);
 	}
 
+	// Initialize selection vector
+	result->match_sel.Initialize();
+
 	// Initialize the storage scan state
 	result->local_storage_state.Initialize(result->phyiscal_column_ids, nullptr);
 	local_storage.InitializeScan(table.GetStorage(), result->local_storage_state.local_state, nullptr);
 
-	// Initialize the table chunk
-	vector<LogicalType> source_types;
-	source_types.insert(source_types.end(), table_types.begin(), table_types.end());
-	source_types.push_back(group_expression->return_type);
-	// TODO: Limit to 2048
-	result->table_chunk.Initialize(context.client, source_types, limit);
-	result->match_sel = SelectionVector(limit);
-
-	result->executor.AddExpression(*proj_expression);
+	// Initialize the index scan state
+	result->index_state = hnsw_index.InitializeMultiScan(context.client);
 
 	return std::move(result);
 }
 
 OperatorResultType PhysicalHNSWIndexJoin::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
-					   GlobalOperatorState &gstate, OperatorState &ostate) const {
-
-	// Get a reference to the state and transaction
+												   GlobalOperatorState &gstate, OperatorState &ostate) const {
 	auto &state = ostate.Cast<HNSWIndexJoinState>();
 	auto &transcation = DuckTransaction::Get(context.client, table.catalog);
 
-	// Get the vector from the input
+	// TODO: Assert that limit is at most 2048
+
+	// TODO: dont flatten
 	input.Flatten();
-	auto &array_vector = ArrayVector::GetEntry(input.data[0]);
-	const auto array_data = FlatVector::GetData<float>(array_vector);
 
-	// TODO: reserve more
-	ListVector::Reserve(chunk.data[0], limit);
-	auto result_list_vector = ListVector::GetEntry(chunk.data[0]);
-	auto result_list_entries = ListVector::GetData(chunk.data[0]);
+	auto &rhs_vector_vector = input.data[rhs_vector_column];
+	auto &rhs_vector_child = ArrayVector::GetEntry(rhs_vector_vector);
+	const auto rhs_vector_size = ArrayType::GetSize(rhs_vector_vector.GetType());
+	const auto rhs_vector_ptr = FlatVector::GetData<float>(rhs_vector_child);
 
-	while(state.input_idx < input.size()) {
-		const auto array_ptr = array_data + state.input_idx * limit;
-		state.index_state = hnsw_index.InitializeScan(array_ptr, limit, context.client);
+	hnsw_index.ResetMultiScan(*state.index_state);
 
-		// Scan the index for row id's
-		const auto match_count = hnsw_index.Scan(*state.index_state, state.row_ids);
-		if(match_count == 0) {
-			result_list_entries[state.input_idx] = list_entry_t { 0, 0 };
-			state.input_idx++;
-			continue;
+	// How many batches are we going to process?
+	const auto batch_count = MinValue(input.size() - state.input_idx, STANDARD_VECTOR_SIZE / limit);
+	idx_t output_idx = 0;
+	for(idx_t batch_idx = 0; batch_idx < batch_count; batch_idx++, state.input_idx++) {
+
+		// Get the next batch
+		const auto rhs_vector_data = rhs_vector_ptr + batch_idx * rhs_vector_size;
+
+		// Scan the index for row ids
+		const auto match_count = hnsw_index.ExecuteMultiScan(*state.index_state, rhs_vector_data, limit);
+		for(idx_t i = 0; i < match_count; i++) {
+			state.match_sel.set_index(output_idx++, batch_idx);
 		}
-
-		for(idx_t j = 0; j < match_count; j++) {
-			state.match_sel.set_index(j, state.input_idx);
-		}
-
-		// Scan the table for the matching rows
-		table.GetStorage().Fetch(transcation, state.table_chunk, state.phyiscal_column_ids, state.row_ids, match_count, state.fetch_state);
-
-		// Reference the current search vector
-		state.table_chunk.data[state.table_chunk.data.size() - 1].Slice(input.data[0], state.match_sel, match_count);
-
-		// Set the cardinality
-		state.table_chunk.SetCardinality(match_count);
-
-		// execute the expression
-		state.executor.ExecuteExpression(state.table_chunk, result_list_vector);
-
-		result_list_entries[state.input_idx] = list_entry_t { 0, match_count };
-		ConstantVector::Reference(chunk.data[1], input.data[0], state.input_idx, input.size());
-		chunk.SetCardinality(1);
-
-		ListVector::SetListSize(chunk.data[0], match_count);
-
-		state.input_idx++;
-		return OperatorResultType::HAVE_MORE_OUTPUT;
 	}
-	return OperatorResultType::NEED_MORE_INPUT;
+
+	const auto &row_ids = hnsw_index.GetMultiScanResult(*state.index_state);
+
+	// Execute one big fetch for the LHS
+	table.GetStorage().Fetch(transcation, chunk, state.phyiscal_column_ids, row_ids, output_idx, state.fetch_state);
+
+	// Now slice the chunk so that we include the rhs too
+	chunk.Slice(input, state.match_sel, output_idx, state.phyiscal_column_ids.size());
+
+	// Set the cardinality
+	chunk.SetCardinality(output_idx);
+
+	if(state.input_idx == input.size()) {
+		state.input_idx = 0;
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+
+	return OperatorResultType::HAVE_MORE_OUTPUT;
 }
 
 //------------------------------------------------------------------------------
@@ -177,351 +163,410 @@ OperatorResultType PhysicalHNSWIndexJoin::Execute(ExecutionContext &context, Dat
 
 class LogicalHNSWIndexJoin final : public LogicalExtensionOperator {
 public:
-	LogicalHNSWIndexJoin(idx_t table_index_p, DuckTableEntry &table_p, HNSWIndex &hnsw_index_p, idx_t limit_p, const vector<column_t>& table_column_ids_p, const vector<LogicalType>& table_types_p)
-	    : table_index(table_index_p), table(table_p), hnsw_index(hnsw_index_p), limit(limit_p), table_column_ids(table_column_ids_p), table_types(table_types_p) {
+	explicit LogicalHNSWIndexJoin(const idx_t table_index_p, DuckTableEntry &table_p, HNSWIndex &hnsw_index_p, const idx_t limit_p)
+		: table_index(table_index_p), table(table_p), hnsw_index(hnsw_index_p), limit(limit_p) {
 	}
-
 public:
+	string GetName() const override;
 	void ResolveTypes() override;
-	void ResolveColumnBindings(ColumnBindingResolver &res, vector<ColumnBinding> &bindings) override;
 	vector<ColumnBinding> GetColumnBindings() override;
-
-	string GetExtensionName() const override;
+	vector<ColumnBinding> GetLeftBindings();
+	vector<ColumnBinding> GetRightBindings();
 	unique_ptr<PhysicalOperator> CreatePlan(ClientContext &context, PhysicalPlanGenerator &generator) override;
-
-	vector<idx_t> GetTableIndex() const override {
-		return {0};
-	}
 public:
 	idx_t table_index;
+
 	DuckTableEntry &table;
 	HNSWIndex &hnsw_index;
-	unique_ptr<Expression> projection_expression;
 	idx_t limit;
 
-	vector<column_t> table_column_ids;
-	vector<LogicalType> table_types;
+	vector<column_t> lhs_column_ids;
+	vector<idx_t> lhs_projection_ids;
+	vector<LogicalType> lhs_returned_types;
+
+	idx_t lhs_vector_column;
+	idx_t rhs_vector_column;
 };
 
-//------------------------------------------------------------------------------
-// Methods
-//------------------------------------------------------------------------------
+string LogicalHNSWIndexJoin::GetName() const {
+	return "HNSW_INDEX_JOIN";
+}
 
 void LogicalHNSWIndexJoin::ResolveTypes() {
-	types.push_back(LogicalType::LIST(projection_expression->return_type));
-	D_ASSERT(expressions.size() == 1);
-	types.push_back(expressions[0]->return_type);
+	if(lhs_column_ids.empty()) {
+		lhs_column_ids.push_back(COLUMN_IDENTIFIER_ROW_ID);
+	}
+	types.clear();
+
+	if (lhs_projection_ids.empty()) {
+		for (const auto &index : lhs_column_ids) {
+			if (index == COLUMN_IDENTIFIER_ROW_ID) {
+				types.emplace_back(LogicalType::ROW_TYPE);
+			} else {
+				types.push_back(lhs_returned_types[index]);
+			}
+		}
+	} else {
+		for (const auto &proj_index : lhs_projection_ids) {
+			const auto &index = lhs_column_ids[proj_index];
+			if (index == COLUMN_IDENTIFIER_ROW_ID) {
+				types.emplace_back(LogicalType::ROW_TYPE);
+			} else {
+				types.push_back(lhs_returned_types[index]);
+			}
+		}
+	}
+
+	// Also add the types of the right hand side
+	auto &right_types = children[0]->types;
+	types.insert(types.end(), right_types.begin(), right_types.end());
+}
+
+
+vector<ColumnBinding> LogicalHNSWIndexJoin::GetLeftBindings() {
+	vector<ColumnBinding> result;
+	if(lhs_projection_ids.empty()) {
+		for(idx_t col_idx = 0; col_idx < lhs_column_ids.size(); col_idx++) {
+			result.emplace_back(table_index, col_idx);
+		}
+	} else {
+		for(auto proj_id : lhs_projection_ids) {
+			result.emplace_back(table_index, proj_id);
+		}
+	}
+	return result;
+}
+
+vector<ColumnBinding> LogicalHNSWIndexJoin::GetRightBindings() {
+	vector<ColumnBinding> result;
+	for(auto &binding : children[0]->GetColumnBindings()) {
+		result.push_back(binding);
+	}
+	return result;
 }
 
 vector<ColumnBinding> LogicalHNSWIndexJoin::GetColumnBindings() {
-	return GenerateColumnBindings(table_index, types.size());
+	vector<ColumnBinding> result;
+	auto left_bindings = GetLeftBindings();
+	auto right_bindings = GetRightBindings();
+	result.insert(result.end(), left_bindings.begin(), left_bindings.end());
+	result.insert(result.end(), right_bindings.begin(), right_bindings.end());
+	return result;
 }
 
-void LogicalHNSWIndexJoin::ResolveColumnBindings(ColumnBindingResolver &res, vector<ColumnBinding> &bindings) {
-	for (auto &child : children) {
-		res.VisitOperator(*child);
-	}
-	LogicalOperatorVisitor::EnumerateExpressions(*this, [&](unique_ptr<Expression> *child) { res.VisitExpression(child); });
-	bindings = GetColumnBindings();
-}
+unique_ptr<PhysicalOperator> LogicalHNSWIndexJoin::CreatePlan(ClientContext &context,
+															  PhysicalPlanGenerator &generator) {
+	auto result = make_uniq<PhysicalHNSWIndexJoin>(types, 0, table, hnsw_index, limit);
+	result->limit = limit;
+	result->lhs_column_ids = lhs_column_ids;
+	result->lhs_projection_ids = lhs_projection_ids;
+	result->lhs_vector_column = lhs_vector_column;
+	result->rhs_vector_column = rhs_vector_column;
 
-string LogicalHNSWIndexJoin::GetExtensionName() const {
-	return "hnsw_index_join";
-}
-
-unique_ptr<PhysicalOperator> LogicalHNSWIndexJoin::CreatePlan(ClientContext &context, PhysicalPlanGenerator &generator) {
-	auto result = make_uniq<PhysicalHNSWIndexJoin>(types, table, hnsw_index, limit, table_column_ids, table_types);
+	// Plan the	child
 	result->children.push_back(generator.CreatePlan(std::move(children[0])));
-	// Convert the projection expression
 
-	result->proj_expression = projection_expression->Copy();
-	D_ASSERT(expressions.size() == 1);
-	result->group_expression = expressions[0]->Copy();
 	return std::move(result);
 }
 
+//------------------------------------------------------------------------------
+// Optimizer
+//------------------------------------------------------------------------------
 
-// bindings[0] = the aggregate_function
-// bindings[1] = the column ref
-// bindings[2] = the distance function
-// bindings[3] = the arg ref
-// bindings[4] = the matched vector
-// bindings[5] = the k value
-static bool MatchDistanceFunction(vector<reference<Expression>> &bindings, Expression &agg_expr, Expression &column_ref,
-                                  idx_t vector_size) {
+class HNSWIndexJoinOptimizer : public OptimizerExtension {
+public:
+	HNSWIndexJoinOptimizer();
+	static bool TryOptimize(Binder &binder, ClientContext &context, unique_ptr<LogicalOperator> &root, unique_ptr<LogicalOperator> &plan);
+	static void OptimizeRecursive(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &root, unique_ptr<LogicalOperator> &plan);
+	static void Optimize(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan);
+};
 
-	AggregateFunctionExpressionMatcher min_by_matcher;
-	min_by_matcher.function = make_uniq<SpecificFunctionMatcher>("min_by");
-	min_by_matcher.policy = SetMatcher::Policy::ORDERED;
-
-	unordered_set<string> distance_functions = {
-	    "array_distance", "<->", "array_cosine_distance", "<=>", "array_negative_inner_product", "<#>"};
-
-	auto distance_matcher = make_uniq<FunctionExpressionMatcher>();
-	distance_matcher->function = make_uniq<ManyFunctionMatcher>(distance_functions);
-	distance_matcher->expr_type = make_uniq<SpecificExpressionTypeMatcher>(ExpressionType::BOUND_FUNCTION);
-	distance_matcher->policy = SetMatcher::Policy::UNORDERED;
-	distance_matcher->matchers.push_back(make_uniq<ExpressionEqualityMatcher>(column_ref));
-
-	auto vector_matcher = make_uniq<ExpressionMatcher>();
-	vector_matcher->type = make_uniq<SpecificTypeMatcher>(LogicalType::ARRAY(LogicalType::FLOAT, vector_size));
-	distance_matcher->matchers.push_back(std::move(vector_matcher)); // The vector to match
-
-	min_by_matcher.matchers.push_back(make_uniq<ExpressionMatcher>()); // Dont care about the column
-	min_by_matcher.matchers.push_back(std::move(distance_matcher));
-	min_by_matcher.matchers.push_back(make_uniq<ConstantExpressionMatcher>()); // The k value
-
-	return min_by_matcher.Match(agg_expr, bindings);
+HNSWIndexJoinOptimizer::HNSWIndexJoinOptimizer() {
+	optimize_function = Optimize;
 }
 
+bool HNSWIndexJoinOptimizer::TryOptimize(Binder &binder, ClientContext &context, unique_ptr<LogicalOperator> &root, unique_ptr<LogicalOperator> &plan) {
+
+	//------------------------------------------------------------------------------
+	// Look for:
+	// delim_join
+	//	-> seq_scan (lhs)
+	//  -> projection
+	//		-> filter
+	//			-> window
+	//				-> projection
+	//					-> cross_product
+	//						-> delim_get
+	//						-> seq_scan(rhs)
+	//------------------------------------------------------------------------------
+
+	//------------------------------------------------------------------------------
+	// Match Operators
+	//------------------------------------------------------------------------------
+#define MATCH_OPERATOR(OP, TYPE, CHILD_COUNT) if(OP->type != LogicalOperatorType::TYPE || (OP->children.size() != CHILD_COUNT)) { return false; }
+	MATCH_OPERATOR(plan, LOGICAL_PROJECTION, 1);
+	auto &top_proj = plan->Cast<LogicalProjection>();
+
+	MATCH_OPERATOR(top_proj.children.back(), LOGICAL_DELIM_JOIN, 2);
+	auto &delim_join = top_proj.children.back()->Cast<LogicalJoin>();
+
+	MATCH_OPERATOR(delim_join.children[0], LOGICAL_PROJECTION, 1)
+	auto &filter_proj = delim_join.children[0]->Cast<LogicalProjection>();
+
+	MATCH_OPERATOR(delim_join.children[1], LOGICAL_GET, 0);
+	auto &lhs_get = delim_join.children[1]->Cast<LogicalGet>();
+	if(lhs_get.function.name != "seq_scan") {
+		return false;
+	}
+
+	MATCH_OPERATOR(filter_proj.children[0], LOGICAL_FILTER, 1);
+	auto &filter = filter_proj.children[0]->Cast<LogicalFilter>();
+
+	MATCH_OPERATOR(filter.children[0], LOGICAL_WINDOW, 1);
+	auto &window = filter.children[0]->Cast<LogicalWindow>();
+
+	MATCH_OPERATOR(window.children[0], LOGICAL_PROJECTION, 1);
+	auto &distance_proj = window.children[0]->Cast<LogicalProjection>();
+
+	MATCH_OPERATOR(distance_proj.children[0], LOGICAL_CROSS_PRODUCT, 2);
+	auto &cross_product = distance_proj.children[0]->Cast<LogicalCrossProduct>();
+#undef MATCH_OPERATOR
+
+	// Extract the delim_get and the rhs_get
+	unique_ptr<LogicalOperator>* delim_get_ptr;
+	unique_ptr<LogicalOperator>* rhs_get_ptr;
+
+	auto &cp_lhs = cross_product.children[0];
+	auto &cp_rhs = cross_product.children[1];
+	if(cp_lhs->type == LogicalOperatorType::LOGICAL_DELIM_GET && cp_rhs->type == LogicalOperatorType::LOGICAL_GET) {
+		delim_get_ptr = &cp_lhs;;
+		rhs_get_ptr = &cp_rhs;
+	}
+	else if(cp_rhs->type == LogicalOperatorType::LOGICAL_DELIM_GET && cp_lhs->type == LogicalOperatorType::LOGICAL_GET) {
+		delim_get_ptr = &cp_rhs;
+		rhs_get_ptr = &cp_lhs;
+	}
+	else {
+		return false;
+	}
+
+	const auto &delim_get = (*delim_get_ptr)->Cast<LogicalDelimGet>();
+	const auto &rhs_get = (*rhs_get_ptr)->Cast<LogicalGet>();
+	if(rhs_get.function.name != "seq_scan") {
+		return false;
+	}
+
+	//------------------------------------------------------------------------------
+	// Match Expressions
+	//------------------------------------------------------------------------------
+
+	// Verify that the filter is filtering on the window row number
+	if(filter.expressions.size() != 1) {
+		return false;
+	}
+	if(filter.expressions.back()->type != ExpressionType::COMPARE_LESSTHANOREQUALTO) {
+		return false;
+	}
+	auto &compare_expr = filter.expressions.back()->Cast<BoundComparisonExpression>();
+	if(compare_expr.right->type != ExpressionType::VALUE_CONSTANT) {
+		return false;
+	}
+	auto &constant_expr = compare_expr.right->Cast<BoundConstantExpression>();
+	if(constant_expr.return_type != LogicalType::BIGINT) {
+		return false;
+	}
+	auto k_value = constant_expr.value.GetValue<int64_t>();
+	if(k_value < 0 || k_value >= STANDARD_VECTOR_SIZE) {
+		// Can only optimize up to SVS
+		return false;
+	}
+	if(compare_expr.left->type != ExpressionType::BOUND_COLUMN_REF) {
+		return false;
+	}
+	auto &filter_ref_expr = compare_expr.left->Cast<BoundColumnRefExpression>();
+	if(filter_ref_expr.binding.table_index != window.window_index) {
+		return false;
+	}
+	if(filter_ref_expr.binding.column_index != 0) {
+		return false;
+	}
+
+	// Verify that the window is ordering on a distance function
+	if(window.expressions.size() != 1) {
+		return false;
+	}
+	if(window.expressions.back()->type != ExpressionType::WINDOW_ROW_NUMBER) {
+		return false;
+	}
+	auto &window_expr = window.expressions.back()->Cast<BoundWindowExpression>();
+	if(window_expr.orders.size() != 1) {
+		return false;
+	}
+	if(window_expr.orders.back().type != OrderType::ASCENDING) {
+		return false;
+	}
+	if(window_expr.orders.back().expression->type != ExpressionType::BOUND_COLUMN_REF) {
+		return false;
+	}
+	auto &distance_ref_expr = window_expr.orders.back().expression->Cast<BoundColumnRefExpression>();
 
 
-struct ProjectionMerger final : LogicalOperatorVisitor {
-	LogicalProjection *child_proj = nullptr;
+	// Verify that this column ref references the distance expression in the projection
+	if(distance_ref_expr.binding.table_index != distance_proj.table_index) {
+		return false;
+	}
+	if(distance_ref_expr.binding.column_index >= distance_proj.expressions.size()) {
+		return false;
+	}
+	auto &distance_expr_ptr = distance_proj.expressions[distance_ref_expr.binding.column_index];
 
-	void VisitOperator(LogicalOperator &op) override {
-		if(op.type == LogicalOperatorType::LOGICAL_PROJECTION || op.type == LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY) {
-			for(auto &child : op.children) {
-				while(child->type == LogicalOperatorType::LOGICAL_PROJECTION) {
-					child_proj = &child->Cast<LogicalProjection>();
-					VisitOperatorExpressions(op);
-					// Replace the child with its own child
-					D_ASSERT(child->children.size() == 1);
-					child = std::move(child->children.back());
+	//------------------------------------------------------------------------------
+	// Match the index
+	//------------------------------------------------------------------------------
+	auto &table = *lhs_get.GetTable();
+	if (!table.IsDuckTable()) {
+		// We can only replace the scan if the table is a duck table
+		return false;
+	}
+	auto &duck_table = table.Cast<DuckTableEntry>();
+	auto &table_info = *table.GetStorage().GetDataTableInfo();
+
+	HNSWIndex *index_ptr = nullptr;
+	vector<reference<Expression>> bindings;
+	table_info.GetIndexes().BindAndScan<HNSWIndex>(context, table_info, [&](HNSWIndex &hnsw_index) {
+		bindings.clear();
+		if(!hnsw_index.TryMatchDistanceFunction(distance_expr_ptr, bindings)) {
+			return false;
+		}
+		unique_ptr<Expression> bound_index_expr = nullptr;
+		if(!hnsw_index.TryBindIndexExpression(lhs_get, bound_index_expr)) {
+			return false;
+		}
+
+		// We also have to replace the table index here with the delim_get table index
+		ExpressionIterator::EnumerateExpression(bound_index_expr, [&](Expression &child) {
+			if(child.type == ExpressionType::BOUND_COLUMN_REF) {
+				auto &bound_colref_expr = child.Cast<BoundColumnRefExpression>();
+				if(bound_colref_expr.binding.table_index == lhs_get.table_index) {
+					bound_colref_expr.binding.table_index = delim_get.table_index;
 				}
 			}
-			// Visit the children
-			VisitOperatorChildren(op);
-		}
-	}
-
-	void VisitExpression(unique_ptr<Expression> *expression) override {
-		if(expression->get()->type == ExpressionType::BOUND_COLUMN_REF) {
-			const auto &ref = expression->get()->Cast<BoundColumnRefExpression>();
-			if(ref.binding.table_index == child_proj->table_index) {
-				// Replace the column reference with the expression
-				*expression = child_proj->expressions[ref.binding.column_index]->Copy();
-				return;
-			}
-		}
-
-		VisitExpressionChildren(**expression);
-	}
-
-	static void MergeProjections(LogicalOperator &op) {
-		ProjectionMerger inliner;
-		inliner.VisitOperator(op);
-	}
-};
-
-//------------------------------------------------------------------------------
-// Main Optimizer
-//------------------------------------------------------------------------------
-// This optimizer rewrites
-//
-//	AGG(MIN_BY(t1.col1, distance_func(t1.col2, query_vector), k)) <- TABLE_SCAN(t1)
-//  =>
-//	AGG(LIST(col1 ORDER BY distance_func(col2, query_vector) ASC)) <- HNSW_INDEX_SCAN(t1, query_vector, k)
-//
-
-class HNSWJoinOptimizer : public OptimizerExtension {
-public:
-	HNSWJoinOptimizer() {
-		optimize_function = Optimize;
-	}
-
-	static bool TryOptimize(Binder &binder, ClientContext &context, unique_ptr<LogicalOperator> &root, unique_ptr<LogicalOperator> &plan) {
-		// Look for a Aggregate operator
-		if(plan->children.empty()) {
-			return false;
-		}
-
-		optional_idx child_idx = optional_idx::Invalid();
-		for(idx_t i = 0; i < plan->children.size(); i++) {
-			if(plan->children[i]->type == LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY) {
-				child_idx = i;
-			}
-		}
-		if(!child_idx.IsValid()) {
-			return false;
-		}
-		// Look for a expression that is a distance expression
-		auto &agg = plan->children[child_idx.GetIndex()]->Cast<LogicalAggregate>();
-		if (agg.groups.size() != 1 || agg.expressions.size() != 1) {
-			return false;
-		}
-
-		// we need the aggregate to be on top of a projection
-		if (agg.children.size() != 1) {
-			return false;
-		}
-
-		if(agg.children.back().get()->type != LogicalOperatorType::LOGICAL_PROJECTION) {
-			return false;
-		}
-
-		// Save the aggregate bindings
-		// This is going to be
-		// 0. the grouping expression
-		//	basically, the LHS vector column: s_vec
-		// 1. the resulting expression
-		//	basically, the result of the aggregate function: min_by(struct_pack(...), score, 3)
-		auto old_agg_bindings = agg.GetColumnBindings();
-
-		// What we need to return is: the same expression as passed in the min_by function.
-		// This is going to be a struct of columns from the right table.
-		// This is the same as bindings[1] we extract down below.
-		// Except we also get the "score" distance metric.
-		// But that will always be the last column.
-
-
-		// Squash the projections
-		ProjectionMerger::MergeProjections(agg);
-
-		// There can be an arbitrary amount of chained projections here
-		LogicalOperator* current = agg.children[0].get();
-		while(current->type == LogicalOperatorType::LOGICAL_PROJECTION) {
-			auto &proj = current->Cast<LogicalProjection>();
-			if (proj.children.size() != 1) {
-				return false;
-			}
-			current = proj.children[0].get();
-		}
-
-		if(current->type != LogicalOperatorType::LOGICAL_CROSS_PRODUCT || current->children.size() != 2) {
-			return false;
-		}
-		auto &cp = current->Cast<LogicalCrossProduct>();
-		// The cross product needs to be on top of a table scan
-
-		if(cp.children[0]->type != LogicalOperatorType::LOGICAL_GET) {
-			return false;
-		}
-
-		auto &table_scan_ptr = cp.children[0];
-		auto &table_scan = table_scan_ptr->Cast<LogicalGet>();
-		if(table_scan.function.name != "seq_scan") {
-			return false;
-		}
-
-		if(cp.children[1]->type != LogicalOperatorType::LOGICAL_DELIM_GET) {
-			return false;
-		}
-		auto &delim_scan_ptr = cp.children[1];
-		auto &delim_scan = delim_scan_ptr->Cast<LogicalDelimGet>();
-
-
-		// Get the table
-		auto &table = *table_scan.GetTable();
-		if (!table.IsDuckTable()) {
-			return false;
-		}
-
-		auto &duck_table = table.Cast<DuckTableEntry>();
-		auto &table_info = *table.GetStorage().GetDataTableInfo();
-
-		unique_ptr<HNSWIndexScanBindData> bind_data = nullptr;
-		vector<reference<Expression>> bindings;
-
-		table_info.GetIndexes().BindAndScan<HNSWIndex>(context, table_info, [&](HNSWIndex &hnsw_index) {
-			// Check that the HNSW index actually indexes the expression
-			const auto index_expr = hnsw_index.unbound_expressions[0]->Copy();
-			if (!hnsw_index.CanRewriteIndexExpression(table_scan, *index_expr)) {
-				return false;
-			}
-
-			const auto vector_size = hnsw_index.GetVectorSize();
-
-			// Reset the bindings
-			bindings.clear();
-			if (!MatchDistanceFunction(bindings, *agg.expressions[0], *index_expr, vector_size)) {
-				return false;
-			}
-			// bindings[0] = the aggregate_function
-			// bindings[1] = the column ref
-			// bindings[2] = the distance function
-			// bindings[3] = the arg ref
-			// bindings[4] = the matching vector column
-			// bindings[5] = the k value
-
-			const auto &distance_func = bindings[2].get().Cast<BoundFunctionExpression>();
-			if (!hnsw_index.MatchesDistanceFunction(distance_func.function.name)) {
-				return false;
-			}
-
-			const auto k_limit = bindings[5].get().Cast<BoundConstantExpression>().value.GetValue<int32_t>();
-			bind_data = make_uniq<HNSWIndexScanBindData>(duck_table, hnsw_index, k_limit, nullptr);
-			return true;
 		});
 
-		if (!bind_data) {
-			// No index found
-			return false;
-		}
+		auto &lhs_dist_expr = bindings[1];
+		auto &rhs_dist_expr = bindings[2];
 
-
-		// Ok, so here's whats going to happen:
-		// We are going to remove the table scan entirely. The index join will take care of that.
-		// To that end, we will only return two bindings: the group and the list of rows (structs) from the what used to
-		// be the table scan. We can move in the expressions into the index join, and replace their bindings with physical bindings
-		// into a temporary execution chunk that we populate right after scanning the index.
-
-		// Before we create the index join, resolve the physical bindings of the agg projection
-		// We will mimic the cross product layout within the HNSW index join
-		const auto group_expr = bindings[4].get().Copy();
-
-		ColumnBindingResolver resolver;
-		resolver.VisitOperator(agg);
-
-		auto index_join = make_uniq<LogicalHNSWIndexJoin>(binder.GenerateTableIndex(),
-			duck_table, bind_data->index.Cast<HNSWIndex>(), bind_data->limit, table_scan.GetColumnIds(), table_scan.types);
-		//index_join->children.push_back(std::move(table_scan_ptr));
-		index_join->children.push_back(std::move(delim_scan_ptr));
-
-		const auto &projection_expr = bindings[1].get();
-		index_join->projection_expression = projection_expr.Copy();
-		index_join->types.push_back(LogicalType::LIST(projection_expr.return_type));
-
-
-		index_join->types.push_back(group_expr->return_type);
-		index_join->expressions.push_back(group_expr->Copy());
-
-		// Also, replace all the column bindings with our new bindings
-		auto new_agg_bindings = index_join->GetColumnBindings();
-		auto &new_types = index_join->types;
-
-		// The aggregate will have first the groups, then the expressions, then the grouping functions.
-		ColumnBindingReplacer replacer;
-		replacer.replacement_bindings.emplace_back(old_agg_bindings[1], new_agg_bindings[0], new_types[0]);
-		replacer.replacement_bindings.emplace_back(old_agg_bindings[0], new_agg_bindings[1], new_types[1]);
-
-		// Replace this part of the plan with our index join
-		plan->children[child_idx.GetIndex()] = std::move(index_join);
-
-		// Make the plan consistent again, starting from the root
-		// TODO: Setup a stop
-		replacer.VisitOperator(*root);
-
-		return true;
-	}
-
-	static void OptimizeRecursive(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &root, unique_ptr<LogicalOperator> &plan) {
-		if (!TryOptimize(input.optimizer.binder, input.context, root, plan)) {
-			// Recursively optimize the children
-			for (auto &child : plan->children) {
-				OptimizeRecursive(input, root, child);
+		// Figure out which of the arguments to the distance function is the index expression (and move it to the lhs)
+		// If the index expression is not part of this distance function, we can't optimize, return false.
+		if(!lhs_dist_expr.get().Equals(*bound_index_expr)) {
+			if(rhs_dist_expr.get().Equals(*bound_index_expr)) {
+				std::swap(lhs_dist_expr, rhs_dist_expr);
+			} else {
+				return false;
 			}
 		}
+
+		// Save the pointer to the index
+		index_ptr = &hnsw_index;
+		return true;
+	});
+	if(!index_ptr) {
+		return false;
 	}
 
-	static void Optimize(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {
-		OptimizeRecursive(input, plan, plan);
+	// Fuck it, for now dont allow expressions on the index
+	if(bindings[1].get().type != ExpressionType::BOUND_COLUMN_REF) { return false; }
+	if(bindings[2].get().type != ExpressionType::BOUND_COLUMN_REF) { return false; }
+	const auto &lhs_ref_expr = bindings[1].get().Cast<BoundColumnRefExpression>();
+	const auto &rhs_ref_expr = bindings[2].get().Cast<BoundColumnRefExpression>();
+
+	if(rhs_ref_expr.binding.table_index != rhs_get.table_index) {
+		// Well, we have to reference the rhs
+		return false;
 	}
-};
+
+	//------------------------------------------------------------------------------
+	// Now create the HNSWIndexJoin operator
+	//------------------------------------------------------------------------------
+
+	auto index_join = make_uniq<LogicalHNSWIndexJoin>(binder.GenerateTableIndex(), duck_table, *index_ptr, k_value);
+	index_join->lhs_column_ids = lhs_get.GetColumnIds();
+	index_join->lhs_projection_ids = lhs_get.projection_ids;
+	index_join->lhs_returned_types = lhs_get.returned_types;
+
+	// TODO: this is kind of unsafe, column_index != physical index
+	index_join->lhs_vector_column = lhs_ref_expr.binding.column_index;
+	index_join->rhs_vector_column = rhs_ref_expr.binding.column_index;
+
+	// All the expressions of the filter_proj will be bound column refs.
+	// And they will reference columns from the distance_proj.
+	ColumnBindingReplacer replacer;
+
+	// Figure out which bindings we are pulling from the right hand side
+	for(const auto &binding : filter_proj.GetColumnBindings()) {
+
+		// The binding is a bound column ref to the filter
+		const auto &filter_expr = filter_proj.expressions[binding.column_index];
+		D_ASSERT(filter_expr->type == ExpressionType::BOUND_COLUMN_REF);
+		const auto &filter_colref_expr = filter_expr->Cast<BoundColumnRefExpression>();
+
+		// D_ASSERT(filter_colref_expr.binding.table_index == window.window_index);
+
+		const auto &proj_expr = distance_proj.expressions[filter_colref_expr.binding.column_index];
+
+		if(proj_expr->type != ExpressionType::BOUND_COLUMN_REF) {
+			// TODO: Save these and push on top of the cross product later.
+			throw NotImplementedException("Only bound column refs are supported in the filter expression");
+		}
+
+		const auto &proj_colref_expr = proj_expr->Cast<BoundColumnRefExpression>();
+		if(proj_colref_expr.binding.table_index == delim_get.table_index) {
+			ColumnBinding new_binding(index_join->table_index, proj_colref_expr.binding.column_index);
+			replacer.replacement_bindings.emplace_back(binding, new_binding);
+		} else if(proj_colref_expr.binding.table_index == rhs_get.table_index) {
+			// Make it reference the RHS of the cross product (our new join) directly
+			replacer.replacement_bindings.emplace_back(binding, proj_colref_expr.binding);
+		}
+	}
+
+	// Figure out what we are pulling from the left hand side
+	for(const auto &old_lhs_binding : lhs_get.GetColumnBindings()) {
+		ColumnBinding new_binding(index_join->table_index, old_lhs_binding.column_index);
+		replacer.replacement_bindings.emplace_back(old_lhs_binding, new_binding);
+	}
+
+	// Add the RHS of the cross product to the join
+	index_join->children.emplace_back(std::move(*rhs_get_ptr));
+
+	// Swap the plan
+	top_proj.children[0] = std::move(index_join);
+
+	// Replace the bindings
+	replacer.VisitOperator(*root);
+
+	return true;
+}
+
+void HNSWIndexJoinOptimizer::OptimizeRecursive(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &root, unique_ptr<LogicalOperator> &plan) {
+	if (!TryOptimize(input.optimizer.binder, input.context, root, plan)) {
+		// Recursively optimize the children
+		for (auto &child : plan->children) {
+			OptimizeRecursive(input, root, child);
+		}
+	}
+}
+
+void HNSWIndexJoinOptimizer::Optimize(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {
+	OptimizeRecursive(input, plan, plan);
+}
+
+//------------------------------------------------------------------------------
+// Register
+//------------------------------------------------------------------------------
 
 void HNSWModule::RegisterJoinOptimizer(DatabaseInstance &db) {
 	// Register the JoinOptimizer
-	db.config.optimizer_extensions.push_back(HNSWJoinOptimizer());
+	db.config.optimizer_extensions.push_back(HNSWIndexJoinOptimizer());
 }
 
 } // namespace duckdb

--- a/src/hnsw/hnsw_optimize_join.cpp
+++ b/src/hnsw/hnsw_optimize_join.cpp
@@ -1,0 +1,523 @@
+#include "aggregate_function_matcher.hpp"
+#include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/execution/column_binding_resolver.hpp"
+#include "duckdb/optimizer/matcher/expression_matcher.hpp"
+#include "duckdb/optimizer/optimizer.hpp"
+#include "duckdb/planner/expression/bound_aggregate_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
+#include "duckdb/planner/operator/logical_aggregate.hpp"
+#include "duckdb/planner/operator/logical_cross_product.hpp"
+#include "duckdb/planner/operator/logical_delim_get.hpp"
+#include "duckdb/planner/operator/logical_extension_operator.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/planner/operator/logical_projection.hpp"
+#include "duckdb/optimizer/column_binding_replacer.hpp"
+#include "duckdb/storage/table/scan_state.hpp"
+#include "duckdb/transaction/duck_transaction.hpp"
+
+#include "hnsw/hnsw.hpp"
+#include "hnsw/hnsw_index.hpp"
+#include "hnsw/hnsw_index_scan.hpp"
+
+
+namespace duckdb {
+
+//------------------------------------------------------------------------------
+// Physical operator
+//------------------------------------------------------------------------------
+class PhysicalHNSWIndexJoin final : public PhysicalOperator {
+public:
+	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::EXTENSION;
+public:
+	// TODO: Pass estimated cardinality
+	PhysicalHNSWIndexJoin(vector<LogicalType> &types, DuckTableEntry &table_p, HNSWIndex &hnsw_index_p, idx_t limit_p,
+		const vector<column_t>& table_column_ids_p, const vector<LogicalType> &table_types_p)
+		: PhysicalOperator(PhysicalOperatorType::EXTENSION, types, 0), table(table_p),
+	hnsw_index(hnsw_index_p), limit(limit_p), logical_column_ids(table_column_ids_p), table_types(table_types_p) {
+	}
+
+public:
+	string GetName() const override { return "HNSW_INDEX_JOIN"; }
+	bool ParallelOperator() const override { return false; }
+	unique_ptr<OperatorState> GetOperatorState(ExecutionContext &context) const override;
+	OperatorResultType Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+						   GlobalOperatorState &gstate, OperatorState &state) const override;
+public:
+	DuckTableEntry &table;
+	HNSWIndex &hnsw_index;
+
+	// The projection expressions (the struct pack of the rows from the right table)
+	unique_ptr<Expression> proj_expression;
+
+	// The matching vector on the lhs side
+	unique_ptr<Expression> group_expression;
+
+	idx_t limit;
+	vector<column_t> logical_column_ids;
+	vector<LogicalType> table_types;
+};
+
+class HNSWIndexJoinState : public OperatorState {
+public:
+	explicit HNSWIndexJoinState(ClientContext &context) : executor(context) { }
+
+	idx_t input_idx = 0;
+
+	ColumnFetchState fetch_state;
+	TableScanState local_storage_state;
+	vector<storage_t> phyiscal_column_ids;
+
+	// Index scan state
+	unique_ptr<IndexScanState> index_state;
+	Vector row_ids = Vector(LogicalType::ROW_TYPE);
+
+
+	SelectionVector match_sel;
+	DataChunk table_chunk;
+	//DataChunk proj_chunk;
+
+	ExpressionExecutor executor;
+};
+
+unique_ptr<OperatorState> PhysicalHNSWIndexJoin::GetOperatorState(ExecutionContext &context) const {
+	auto result = make_uniq<HNSWIndexJoinState>(context.client);
+
+	auto &local_storage = LocalStorage::Get(context.client, table.catalog);
+	result->phyiscal_column_ids.reserve(logical_column_ids.size());
+
+	// Figure out the storage column ids from the projection expression
+	for(auto &id : logical_column_ids) {
+		storage_t col_id = id;
+		if(id != DConstants::INVALID_INDEX) {
+			col_id = table.GetColumn(LogicalIndex(id)).StorageOid();
+		}
+		result->phyiscal_column_ids.push_back(col_id);
+	}
+
+	// Initialize the storage scan state
+	result->local_storage_state.Initialize(result->phyiscal_column_ids, nullptr);
+	local_storage.InitializeScan(table.GetStorage(), result->local_storage_state.local_state, nullptr);
+
+	// Initialize the table chunk
+	vector<LogicalType> source_types;
+	source_types.insert(source_types.end(), table_types.begin(), table_types.end());
+	source_types.push_back(group_expression->return_type);
+	// TODO: Limit to 2048
+	result->table_chunk.Initialize(context.client, source_types, limit);
+	result->match_sel = SelectionVector(limit);
+
+	result->executor.AddExpression(*proj_expression);
+
+	return std::move(result);
+}
+
+OperatorResultType PhysicalHNSWIndexJoin::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+					   GlobalOperatorState &gstate, OperatorState &ostate) const {
+
+	// Get a reference to the state and transaction
+	auto &state = ostate.Cast<HNSWIndexJoinState>();
+	auto &transcation = DuckTransaction::Get(context.client, table.catalog);
+
+	// Get the vector from the input
+	input.Flatten();
+	auto &array_vector = ArrayVector::GetEntry(input.data[0]);
+	const auto array_data = FlatVector::GetData<float>(array_vector);
+
+	// TODO: reserve more
+	ListVector::Reserve(chunk.data[0], limit);
+	auto result_list_vector = ListVector::GetEntry(chunk.data[0]);
+	auto result_list_entries = ListVector::GetData(chunk.data[0]);
+
+	while(state.input_idx < input.size()) {
+		const auto array_ptr = array_data + state.input_idx * limit;
+		state.index_state = hnsw_index.InitializeScan(array_ptr, limit, context.client);
+
+		// Scan the index for row id's
+		const auto match_count = hnsw_index.Scan(*state.index_state, state.row_ids);
+		if(match_count == 0) {
+			result_list_entries[state.input_idx] = list_entry_t { 0, 0 };
+			state.input_idx++;
+			continue;
+		}
+
+		for(idx_t j = 0; j < match_count; j++) {
+			state.match_sel.set_index(j, state.input_idx);
+		}
+
+		// Scan the table for the matching rows
+		table.GetStorage().Fetch(transcation, state.table_chunk, state.phyiscal_column_ids, state.row_ids, match_count, state.fetch_state);
+
+		// Reference the current search vector
+		state.table_chunk.data[state.table_chunk.data.size() - 1].Slice(input.data[0], state.match_sel, match_count);
+
+		// Set the cardinality
+		state.table_chunk.SetCardinality(match_count);
+
+		// execute the expression
+		state.executor.ExecuteExpression(state.table_chunk, result_list_vector);
+
+		result_list_entries[state.input_idx] = list_entry_t { 0, match_count };
+		ConstantVector::Reference(chunk.data[1], input.data[0], state.input_idx, input.size());
+		chunk.SetCardinality(1);
+
+		ListVector::SetListSize(chunk.data[0], match_count);
+
+		state.input_idx++;
+		return OperatorResultType::HAVE_MORE_OUTPUT;
+	}
+	return OperatorResultType::NEED_MORE_INPUT;
+}
+
+//------------------------------------------------------------------------------
+// Logical Operator
+//------------------------------------------------------------------------------
+
+class LogicalHNSWIndexJoin final : public LogicalExtensionOperator {
+public:
+	LogicalHNSWIndexJoin(idx_t table_index_p, DuckTableEntry &table_p, HNSWIndex &hnsw_index_p, idx_t limit_p, const vector<column_t>& table_column_ids_p, const vector<LogicalType>& table_types_p)
+	    : table_index(table_index_p), table(table_p), hnsw_index(hnsw_index_p), limit(limit_p), table_column_ids(table_column_ids_p), table_types(table_types_p) {
+	}
+
+public:
+	void ResolveTypes() override;
+	void ResolveColumnBindings(ColumnBindingResolver &res, vector<ColumnBinding> &bindings) override;
+	vector<ColumnBinding> GetColumnBindings() override;
+
+	string GetExtensionName() const override;
+	unique_ptr<PhysicalOperator> CreatePlan(ClientContext &context, PhysicalPlanGenerator &generator) override;
+
+	vector<idx_t> GetTableIndex() const override {
+		return {0};
+	}
+public:
+	idx_t table_index;
+	DuckTableEntry &table;
+	HNSWIndex &hnsw_index;
+	unique_ptr<Expression> projection_expression;
+	idx_t limit;
+
+	vector<column_t> table_column_ids;
+	vector<LogicalType> table_types;
+};
+
+//------------------------------------------------------------------------------
+// Methods
+//------------------------------------------------------------------------------
+
+void LogicalHNSWIndexJoin::ResolveTypes() {
+	types.push_back(LogicalType::LIST(projection_expression->return_type));
+	D_ASSERT(expressions.size() == 1);
+	types.push_back(expressions[0]->return_type);
+}
+
+vector<ColumnBinding> LogicalHNSWIndexJoin::GetColumnBindings() {
+	return GenerateColumnBindings(table_index, types.size());
+}
+
+void LogicalHNSWIndexJoin::ResolveColumnBindings(ColumnBindingResolver &res, vector<ColumnBinding> &bindings) {
+	for (auto &child : children) {
+		res.VisitOperator(*child);
+	}
+	LogicalOperatorVisitor::EnumerateExpressions(*this, [&](unique_ptr<Expression> *child) { res.VisitExpression(child); });
+	bindings = GetColumnBindings();
+}
+
+string LogicalHNSWIndexJoin::GetExtensionName() const {
+	return "hnsw_index_join";
+}
+
+unique_ptr<PhysicalOperator> LogicalHNSWIndexJoin::CreatePlan(ClientContext &context, PhysicalPlanGenerator &generator) {
+	auto result = make_uniq<PhysicalHNSWIndexJoin>(types, table, hnsw_index, limit, table_column_ids, table_types);
+	result->children.push_back(generator.CreatePlan(std::move(children[0])));
+	// Convert the projection expression
+
+	result->proj_expression = projection_expression->Copy();
+	D_ASSERT(expressions.size() == 1);
+	result->group_expression = expressions[0]->Copy();
+	return std::move(result);
+}
+
+
+// bindings[0] = the aggregate_function
+// bindings[1] = the column ref
+// bindings[2] = the distance function
+// bindings[3] = the arg ref
+// bindings[4] = the matched vector
+// bindings[5] = the k value
+static bool MatchDistanceFunction(vector<reference<Expression>> &bindings, Expression &agg_expr, Expression &column_ref,
+                                  idx_t vector_size) {
+
+	AggregateFunctionExpressionMatcher min_by_matcher;
+	min_by_matcher.function = make_uniq<SpecificFunctionMatcher>("min_by");
+	min_by_matcher.policy = SetMatcher::Policy::ORDERED;
+
+	unordered_set<string> distance_functions = {
+	    "array_distance", "<->", "array_cosine_distance", "<=>", "array_negative_inner_product", "<#>"};
+
+	auto distance_matcher = make_uniq<FunctionExpressionMatcher>();
+	distance_matcher->function = make_uniq<ManyFunctionMatcher>(distance_functions);
+	distance_matcher->expr_type = make_uniq<SpecificExpressionTypeMatcher>(ExpressionType::BOUND_FUNCTION);
+	distance_matcher->policy = SetMatcher::Policy::UNORDERED;
+	distance_matcher->matchers.push_back(make_uniq<ExpressionEqualityMatcher>(column_ref));
+
+	auto vector_matcher = make_uniq<ExpressionMatcher>();
+	vector_matcher->type = make_uniq<SpecificTypeMatcher>(LogicalType::ARRAY(LogicalType::FLOAT, vector_size));
+	distance_matcher->matchers.push_back(std::move(vector_matcher)); // The vector to match
+
+	min_by_matcher.matchers.push_back(make_uniq<ExpressionMatcher>()); // Dont care about the column
+	min_by_matcher.matchers.push_back(std::move(distance_matcher));
+	min_by_matcher.matchers.push_back(make_uniq<ConstantExpressionMatcher>()); // The k value
+
+	return min_by_matcher.Match(agg_expr, bindings);
+}
+
+
+struct ProjectionMerger final : LogicalOperatorVisitor {
+	LogicalProjection *child_proj = nullptr;
+
+	void VisitOperator(LogicalOperator &op) override {
+		for(auto &child : op.children) {
+			while(child->type == LogicalOperatorType::LOGICAL_PROJECTION) {
+				child_proj = &child->Cast<LogicalProjection>();
+				VisitOperatorExpressions(op);
+				// Replace the child with its own child
+				child = std::move(child->children.back());
+			}
+		}
+		// Visit the children
+		VisitOperatorChildren(op);
+	}
+
+	void VisitExpression(unique_ptr<Expression> *expression) override {
+		if(expression->get()->type == ExpressionType::BOUND_COLUMN_REF) {
+			const auto &ref = expression->get()->Cast<BoundColumnRefExpression>();
+			if(ref.binding.table_index == child_proj->table_index) {
+				// Replace the column reference with the expression
+				*expression = child_proj->expressions[ref.binding.column_index]->Copy();
+				return;
+			}
+		}
+
+		VisitExpressionChildren(**expression);
+	}
+
+	static void MergeProjections(LogicalOperator &op) {
+		ProjectionMerger inliner;
+		inliner.VisitOperator(op);
+	}
+};
+
+//------------------------------------------------------------------------------
+// Main Optimizer
+//------------------------------------------------------------------------------
+// This optimizer rewrites
+//
+//	AGG(MIN_BY(t1.col1, distance_func(t1.col2, query_vector), k)) <- TABLE_SCAN(t1)
+//  =>
+//	AGG(LIST(col1 ORDER BY distance_func(col2, query_vector) ASC)) <- HNSW_INDEX_SCAN(t1, query_vector, k)
+//
+
+class HNSWJoinOptimizer : public OptimizerExtension {
+public:
+	HNSWJoinOptimizer() {
+		optimize_function = Optimize;
+	}
+
+	static bool TryOptimize(Binder &binder, ClientContext &context, unique_ptr<LogicalOperator> &root, unique_ptr<LogicalOperator> &plan) {
+		// Look for a Aggregate operator
+		if(plan->children.empty()) {
+			return false;
+		}
+
+		optional_idx child_idx = optional_idx::Invalid();
+		for(idx_t i = 0; i < plan->children.size(); i++) {
+			if(plan->children[i]->type == LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY) {
+				child_idx = i;
+			}
+		}
+		if(!child_idx.IsValid()) {
+			return false;
+		}
+		// Look for a expression that is a distance expression
+		auto &agg = plan->children[child_idx.GetIndex()]->Cast<LogicalAggregate>();
+		if (agg.groups.size() != 1 || agg.expressions.size() != 1) {
+			return false;
+		}
+
+		// we need the aggregate to be on top of a projection
+		if (agg.children.size() != 1) {
+			return false;
+		}
+
+		if(agg.children.back().get()->type != LogicalOperatorType::LOGICAL_PROJECTION) {
+			return false;
+		}
+
+		// Save the aggregate bindings
+		// This is going to be
+		// 0. the grouping expression
+		//	basically, the LHS vector column: s_vec
+		// 1. the resulting expression
+		//	basically, the result of the aggregate function: min_by(struct_pack(...), score, 3)
+		auto old_agg_bindings = agg.GetColumnBindings();
+
+		// What we need to return is: the same expression as passed in the min_by function.
+		// This is going to be a struct of columns from the right table.
+		// This is the same as bindings[1] we extract down below.
+		// Except we also get the "score" distance metric.
+		// But that will always be the last column.
+
+
+		// Squash the projections
+		ProjectionMerger::MergeProjections(agg);
+
+		// There can be an arbitrary amount of chained projections here
+		LogicalOperator* current = agg.children[0].get();
+		while(current->type == LogicalOperatorType::LOGICAL_PROJECTION) {
+			auto &proj = current->Cast<LogicalProjection>();
+			if (proj.children.size() != 1) {
+				return false;
+			}
+			current = proj.children[0].get();
+		}
+
+		if(current->type != LogicalOperatorType::LOGICAL_CROSS_PRODUCT || current->children.size() != 2) {
+			return false;
+		}
+		auto &cp = current->Cast<LogicalCrossProduct>();
+		// The cross product needs to be on top of a table scan
+
+		if(cp.children[0]->type != LogicalOperatorType::LOGICAL_GET) {
+			return false;
+		}
+
+		auto &table_scan_ptr = cp.children[0];
+		auto &table_scan = table_scan_ptr->Cast<LogicalGet>();
+		if(table_scan.function.name != "seq_scan") {
+			return false;
+		}
+
+		if(cp.children[1]->type != LogicalOperatorType::LOGICAL_DELIM_GET) {
+			return false;
+		}
+		auto &delim_scan_ptr = cp.children[1];
+		auto &delim_scan = delim_scan_ptr->Cast<LogicalDelimGet>();
+
+
+		// Get the table
+		auto &table = *table_scan.GetTable();
+		if (!table.IsDuckTable()) {
+			return false;
+		}
+
+		auto &duck_table = table.Cast<DuckTableEntry>();
+		auto &table_info = *table.GetStorage().GetDataTableInfo();
+
+		unique_ptr<HNSWIndexScanBindData> bind_data = nullptr;
+		vector<reference<Expression>> bindings;
+
+		table_info.GetIndexes().BindAndScan<HNSWIndex>(context, table_info, [&](HNSWIndex &hnsw_index) {
+			// Check that the HNSW index actually indexes the expression
+			const auto index_expr = hnsw_index.unbound_expressions[0]->Copy();
+			if (!hnsw_index.CanRewriteIndexExpression(table_scan, *index_expr)) {
+				return false;
+			}
+
+			const auto vector_size = hnsw_index.GetVectorSize();
+
+			// Reset the bindings
+			bindings.clear();
+			if (!MatchDistanceFunction(bindings, *agg.expressions[0], *index_expr, vector_size)) {
+				return false;
+			}
+			// bindings[0] = the aggregate_function
+			// bindings[1] = the column ref
+			// bindings[2] = the distance function
+			// bindings[3] = the arg ref
+			// bindings[4] = the matching vector column
+			// bindings[5] = the k value
+
+			const auto &distance_func = bindings[2].get().Cast<BoundFunctionExpression>();
+			if (!hnsw_index.MatchesDistanceFunction(distance_func.function.name)) {
+				return false;
+			}
+
+			const auto k_limit = bindings[5].get().Cast<BoundConstantExpression>().value.GetValue<int32_t>();
+			bind_data = make_uniq<HNSWIndexScanBindData>(duck_table, hnsw_index, k_limit, nullptr);
+			return true;
+		});
+
+		if (!bind_data) {
+			// No index found
+			return false;
+		}
+
+
+		// Ok, so here's whats going to happen:
+		// We are going to remove the table scan entirely. The index join will take care of that.
+		// To that end, we will only return two bindings: the group and the list of rows (structs) from the what used to
+		// be the table scan. We can move in the expressions into the index join, and replace their bindings with physical bindings
+		// into a temporary execution chunk that we populate right after scanning the index.
+
+		// Before we create the index join, resolve the physical bindings of the agg projection
+		// We will mimic the cross product layout within the HNSW index join
+		const auto group_expr = bindings[4].get().Copy();
+
+		ColumnBindingResolver resolver;
+		resolver.VisitOperator(agg);
+
+		auto index_join = make_uniq<LogicalHNSWIndexJoin>(binder.GenerateTableIndex(),
+			duck_table, bind_data->index.Cast<HNSWIndex>(), bind_data->limit, table_scan.GetColumnIds(), table_scan.types);
+		//index_join->children.push_back(std::move(table_scan_ptr));
+		index_join->children.push_back(std::move(delim_scan_ptr));
+
+		const auto &projection_expr = bindings[1].get();
+		index_join->projection_expression = projection_expr.Copy();
+		index_join->types.push_back(LogicalType::LIST(projection_expr.return_type));
+
+
+		index_join->types.push_back(group_expr->return_type);
+		index_join->expressions.push_back(group_expr->Copy());
+
+		// Also, replace all the column bindings with our new bindings
+		auto new_agg_bindings = index_join->GetColumnBindings();
+		auto &new_types = index_join->types;
+
+		// The aggregate will have first the groups, then the expressions, then the grouping functions.
+		ColumnBindingReplacer replacer;
+		replacer.replacement_bindings.emplace_back(old_agg_bindings[1], new_agg_bindings[0], new_types[0]);
+		replacer.replacement_bindings.emplace_back(old_agg_bindings[0], new_agg_bindings[1], new_types[1]);
+
+		// Replace this part of the plan with our index join
+		plan->children[child_idx.GetIndex()] = std::move(index_join);
+
+		// Make the plan consistent again, starting from the root
+		// TODO: Setup a stop
+		replacer.VisitOperator(*root);
+
+		return true;
+	}
+
+	static void OptimizeRecursive(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &root, unique_ptr<LogicalOperator> &plan) {
+		if (!TryOptimize(input.optimizer.binder, input.context, root, plan)) {
+			// Recursively optimize the children
+			for (auto &child : plan->children) {
+				OptimizeRecursive(input, root, child);
+			}
+		}
+	}
+
+	static void Optimize(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {
+		OptimizeRecursive(input, plan, plan);
+	}
+};
+
+void HNSWModule::RegisterJoinOptimizer(DatabaseInstance &db) {
+	// Register the JoinOptimizer
+	db.config.optimizer_extensions.push_back(HNSWJoinOptimizer());
+}
+
+} // namespace duckdb

--- a/src/hnsw/hnsw_optimize_scan.cpp
+++ b/src/hnsw/hnsw_optimize_scan.cpp
@@ -97,12 +97,12 @@ public:
 			bindings.clear();
 
 			// Check that the projection expression is a distance function that matches the index
-			if(!hnsw_index.TryMatchDistanceFunction(projection_expr, bindings)) {
+			if (!hnsw_index.TryMatchDistanceFunction(projection_expr, bindings)) {
 				return false;
 			}
 			// Check that the HNSW index actually indexes the expression
 			unique_ptr<Expression> index_expr;
-			if(!hnsw_index.TryBindIndexExpression(get, index_expr)) {
+			if (!hnsw_index.TryBindIndexExpression(get, index_expr)) {
 				return false;
 			}
 
@@ -110,10 +110,11 @@ public:
 			auto &const_expr_ref = bindings[1];
 			auto &index_expr_ref = bindings[2];
 
-			if(const_expr_ref.get().type != ExpressionType::VALUE_CONSTANT || !index_expr->Equals(index_expr_ref)) {
+			if (const_expr_ref.get().type != ExpressionType::VALUE_CONSTANT || !index_expr->Equals(index_expr_ref)) {
 				// Swap the bindings and try again
 				std::swap(const_expr_ref, index_expr_ref);
-				if(const_expr_ref.get().type != ExpressionType::VALUE_CONSTANT || !index_expr->Equals(index_expr_ref)) {
+				if (const_expr_ref.get().type != ExpressionType::VALUE_CONSTANT ||
+				    !index_expr->Equals(index_expr_ref)) {
 					// Nope, not a match, we can't optimize.
 					return false;
 				}

--- a/src/hnsw/hnsw_optimize_topk.cpp
+++ b/src/hnsw/hnsw_optimize_topk.cpp
@@ -72,17 +72,17 @@ public:
 		}
 
 		auto &agg_expr = agg.expressions[0];
-		if(agg_expr->type != ExpressionType::BOUND_AGGREGATE) {
+		if (agg_expr->type != ExpressionType::BOUND_AGGREGATE) {
 			return false;
 		}
 		auto &agg_func_expr = agg_expr->Cast<BoundAggregateExpression>();
-		if(agg_func_expr.function.name != "min_by") {
+		if (agg_func_expr.function.name != "min_by") {
 			return false;
 		}
-		if(agg_func_expr.children.size() != 3) {
+		if (agg_func_expr.children.size() != 3) {
 			return false;
 		}
-		if(agg_func_expr.children[2]->type != ExpressionType::VALUE_CONSTANT) {
+		if (agg_func_expr.children[2]->type != ExpressionType::VALUE_CONSTANT) {
 			return false;
 		}
 		const auto &col_expr = agg_func_expr.children[0];
@@ -121,12 +121,12 @@ public:
 			bindings.clear();
 
 			// Check that the projection expression is a distance function that matches the index
-			if(!hnsw_index.TryMatchDistanceFunction(dist_expr, bindings)) {
+			if (!hnsw_index.TryMatchDistanceFunction(dist_expr, bindings)) {
 				return false;
 			}
 			// Check that the HNSW index actually indexes the expression
 			unique_ptr<Expression> index_expr;
-			if(!hnsw_index.TryBindIndexExpression(get, index_expr)) {
+			if (!hnsw_index.TryBindIndexExpression(get, index_expr)) {
 				return false;
 			}
 
@@ -134,10 +134,11 @@ public:
 			auto &const_expr_ref = bindings[1];
 			auto &index_expr_ref = bindings[2];
 
-			if(const_expr_ref.get().type != ExpressionType::VALUE_CONSTANT || !index_expr->Equals(index_expr_ref)) {
+			if (const_expr_ref.get().type != ExpressionType::VALUE_CONSTANT || !index_expr->Equals(index_expr_ref)) {
 				// Swap the bindings and try again
 				std::swap(const_expr_ref, index_expr_ref);
-				if(const_expr_ref.get().type != ExpressionType::VALUE_CONSTANT || !index_expr->Equals(index_expr_ref)) {
+				if (const_expr_ref.get().type != ExpressionType::VALUE_CONSTANT ||
+				    !index_expr->Equals(index_expr_ref)) {
 					// Nope, not a match, we can't optimize.
 					return false;
 				}
@@ -152,7 +153,7 @@ public:
 				query_vector[i] = vector_elements[i].GetValue<float>();
 			}
 			const auto k_limit = limit_expr->Cast<BoundConstantExpression>().value.GetValue<int32_t>();
-			if(k_limit <= 0 || k_limit >= STANDARD_VECTOR_SIZE) {
+			if (k_limit <= 0 || k_limit >= STANDARD_VECTOR_SIZE) {
 				return false;
 			}
 			bind_data = make_uniq<HNSWIndexScanBindData>(duck_table, hnsw_index, k_limit, std::move(query_vector));

--- a/src/hnsw/hnsw_optimize_topk.cpp
+++ b/src/hnsw/hnsw_optimize_topk.cpp
@@ -12,8 +12,6 @@
 #include "hnsw/hnsw_index.hpp"
 #include "hnsw/hnsw_index_scan.hpp"
 
-#include "aggregate_function_matcher.hpp"
-
 namespace duckdb {
 
 //------------------------------------------------------------------------------
@@ -46,39 +44,6 @@ static unique_ptr<Expression> CreateListOrderByExpr(ClientContext &context, uniq
 	return new_agg_expr;
 }
 
-// bindings[0] = the aggregate_function
-// bindings[1] = the column ref
-// bindings[2] = the distance function
-// bindings[3] = the arg ref
-// bindings[4] = the matched vector
-// bindings[5] = the k value
-static bool MatchDistanceFunction(vector<reference<Expression>> &bindings, Expression &agg_expr, Expression &column_ref,
-                                  idx_t vector_size) {
-
-	AggregateFunctionExpressionMatcher min_by_matcher;
-	min_by_matcher.function = make_uniq<SpecificFunctionMatcher>("min_by");
-	min_by_matcher.policy = SetMatcher::Policy::ORDERED;
-
-	unordered_set<string> distance_functions = {
-	    "array_distance", "<->", "array_cosine_distance", "<=>", "array_negative_inner_product", "<#>"};
-
-	auto distance_matcher = make_uniq<FunctionExpressionMatcher>();
-	distance_matcher->function = make_uniq<ManyFunctionMatcher>(distance_functions);
-	distance_matcher->expr_type = make_uniq<SpecificExpressionTypeMatcher>(ExpressionType::BOUND_FUNCTION);
-	distance_matcher->policy = SetMatcher::Policy::UNORDERED;
-	distance_matcher->matchers.push_back(make_uniq<ExpressionEqualityMatcher>(column_ref));
-
-	auto vector_matcher = make_uniq<ConstantExpressionMatcher>();
-	vector_matcher->type = make_uniq<SpecificTypeMatcher>(LogicalType::ARRAY(LogicalType::FLOAT, vector_size));
-	distance_matcher->matchers.push_back(std::move(vector_matcher)); // The vector to match
-
-	min_by_matcher.matchers.push_back(make_uniq<ExpressionMatcher>()); // Dont care about the column
-	min_by_matcher.matchers.push_back(std::move(distance_matcher));
-	min_by_matcher.matchers.push_back(make_uniq<ConstantExpressionMatcher>()); // The k value
-
-	return min_by_matcher.Match(agg_expr, bindings);
-}
-
 //------------------------------------------------------------------------------
 // Main Optimizer
 //------------------------------------------------------------------------------
@@ -105,6 +70,24 @@ public:
 		if (!agg.groups.empty() || agg.expressions.size() != 1) {
 			return false;
 		}
+
+		auto &agg_expr = agg.expressions[0];
+		if(agg_expr->type != ExpressionType::BOUND_AGGREGATE) {
+			return false;
+		}
+		auto &agg_func_expr = agg_expr->Cast<BoundAggregateExpression>();
+		if(agg_func_expr.function.name != "min_by") {
+			return false;
+		}
+		if(agg_func_expr.children.size() != 3) {
+			return false;
+		}
+		if(agg_func_expr.children[2]->type != ExpressionType::VALUE_CONSTANT) {
+			return false;
+		}
+		const auto &col_expr = agg_func_expr.children[0];
+		const auto &dist_expr = agg_func_expr.children[1];
+		const auto &limit_expr = agg_func_expr.children[2];
 
 		// we need the aggregate to be on top of a projection
 		if (agg.children.size() != 1) {
@@ -134,41 +117,45 @@ public:
 		vector<reference<Expression>> bindings;
 
 		table_info.GetIndexes().BindAndScan<HNSWIndex>(context, table_info, [&](HNSWIndex &hnsw_index) {
-			// Check that the HNSW index actually indexes the expression
-			const auto index_expr = hnsw_index.unbound_expressions[0]->Copy();
-			if (!hnsw_index.CanRewriteIndexExpression(get, *index_expr)) {
+			// Reset the bindings
+			bindings.clear();
+
+			// Check that the projection expression is a distance function that matches the index
+			if(!hnsw_index.TryMatchDistanceFunction(dist_expr, bindings)) {
 				return false;
+			}
+			// Check that the HNSW index actually indexes the expression
+			unique_ptr<Expression> index_expr;
+			if(!hnsw_index.TryBindIndexExpression(get, index_expr)) {
+				return false;
+			}
+
+			// Now, ensure that one of the bindings is a constant vector, and the other our index expression
+			auto &const_expr_ref = bindings[1];
+			auto &index_expr_ref = bindings[2];
+
+			if(const_expr_ref.get().type != ExpressionType::VALUE_CONSTANT || !index_expr->Equals(index_expr_ref)) {
+				// Swap the bindings and try again
+				std::swap(const_expr_ref, index_expr_ref);
+				if(const_expr_ref.get().type != ExpressionType::VALUE_CONSTANT || !index_expr->Equals(index_expr_ref)) {
+					// Nope, not a match, we can't optimize.
+					return false;
+				}
 			}
 
 			const auto vector_size = hnsw_index.GetVectorSize();
+			const auto &matched_vector = const_expr_ref.get().Cast<BoundConstantExpression>().value;
 
-			// Reset the bindings
-			bindings.clear();
-			if (!MatchDistanceFunction(bindings, *agg.expressions[0], *index_expr, vector_size)) {
-				return false;
-			}
-			// bindings[0] = the aggregate_function
-			// bindings[1] = the column ref
-			// bindings[2] = the distance function
-			// bindings[3] = the arg ref
-			// bindings[4] = the matched vector
-			// bindings[5] = the k value
-
-			const auto &distance_func = bindings[2].get().Cast<BoundFunctionExpression>();
-			if (!hnsw_index.MatchesDistanceFunction(distance_func.function.name)) {
-				return false;
-			}
-
-			const auto &matched_vector = bindings[4].get().Cast<BoundConstantExpression>().value;
 			auto query_vector = make_unsafe_uniq_array<float>(vector_size);
 			auto vector_elements = ArrayValue::GetChildren(matched_vector);
 			for (idx_t i = 0; i < vector_size; i++) {
 				query_vector[i] = vector_elements[i].GetValue<float>();
 			}
-
-			const auto k_limit = bindings[5].get().Cast<BoundConstantExpression>().value.GetValue<int32_t>();
+			const auto k_limit = limit_expr->Cast<BoundConstantExpression>().value.GetValue<int32_t>();
+			if(k_limit <= 0 || k_limit >= STANDARD_VECTOR_SIZE) {
+				return false;
+			}
 			bind_data = make_uniq<HNSWIndexScanBindData>(duck_table, hnsw_index, k_limit, std::move(query_vector));
-
 			return true;
 		});
 
@@ -176,10 +163,6 @@ public:
 			// No index found
 			return false;
 		}
-
-		const auto &agg_expr = bindings[0].get().Cast<BoundAggregateExpression>();
-		const auto &col_expr = bindings[1].get();
-		const auto &distance_func = bindings[2].get().Cast<BoundFunctionExpression>();
 
 		// Replace the aggregate with a index scan + projection
 		get.function = HNSWIndexScanFunction::GetFunction();
@@ -189,8 +172,8 @@ public:
 		get.bind_data = std::move(bind_data);
 
 		// Replace the aggregate with a list() aggregate function ordered by the distance
-		agg.expressions[0] = CreateListOrderByExpr(context, col_expr.Copy(), distance_func.Copy(),
-		                                           agg_expr.filter ? agg_expr.filter->Copy() : nullptr);
+		agg.expressions[0] = CreateListOrderByExpr(context, col_expr->Copy(), dist_expr->Copy(),
+		                                           agg_func_expr.filter ? agg_func_expr.filter->Copy() : nullptr);
 		return true;
 	}
 

--- a/src/hnsw/hnsw_optimize_topk.cpp
+++ b/src/hnsw/hnsw_optimize_topk.cpp
@@ -12,40 +12,13 @@
 #include "hnsw/hnsw_index.hpp"
 #include "hnsw/hnsw_index_scan.hpp"
 
+#include "aggregate_function_matcher.hpp"
+
 namespace duckdb {
 
 //------------------------------------------------------------------------------
 // Optimizer Helpers
 //------------------------------------------------------------------------------
-
-class AggregateFunctionExpressionMatcher : public ExpressionMatcher {
-public:
-	AggregateFunctionExpressionMatcher()
-	    : ExpressionMatcher(ExpressionClass::BOUND_AGGREGATE), policy(SetMatcher::Policy::INVALID) {
-	}
-	//! The matchers for the child expressions
-	vector<unique_ptr<ExpressionMatcher>> matchers;
-	//! The set matcher matching policy to use
-	SetMatcher::Policy policy;
-	//! The function name to match
-	unique_ptr<FunctionMatcher> function;
-
-	bool Match(Expression &expr_p, vector<reference<Expression>> &bindings) override;
-};
-
-bool AggregateFunctionExpressionMatcher::Match(Expression &expr_p, vector<reference<Expression>> &bindings) {
-	if (!ExpressionMatcher::Match(expr_p, bindings)) {
-		return false;
-	}
-	auto &expr = expr_p.Cast<BoundAggregateExpression>();
-	if (!FunctionMatcher::Match(function, expr.function.name)) {
-		return false;
-	}
-	if (!SetMatcher::Match(matchers, expr.children, bindings, policy)) {
-		return false;
-	}
-	return true;
-}
 
 static unique_ptr<Expression> CreateListOrderByExpr(ClientContext &context, unique_ptr<Expression> elem_expr,
                                                     unique_ptr<Expression> order_expr,

--- a/src/include/aggregate_function_matcher.hpp
+++ b/src/include/aggregate_function_matcher.hpp
@@ -1,0 +1,36 @@
+#pragma once
+#include "duckdb/planner/expression/bound_aggregate_expression.hpp"
+#include "duckdb/optimizer/matcher/expression_matcher.hpp"
+
+namespace duckdb {
+
+class AggregateFunctionExpressionMatcher : public ExpressionMatcher {
+public:
+	AggregateFunctionExpressionMatcher()
+		: ExpressionMatcher(ExpressionClass::BOUND_AGGREGATE), policy(SetMatcher::Policy::INVALID) {
+	}
+	//! The matchers for the child expressions
+	vector<unique_ptr<ExpressionMatcher>> matchers;
+	//! The set matcher matching policy to use
+	SetMatcher::Policy policy;
+	//! The function name to match
+	unique_ptr<FunctionMatcher> function;
+
+	bool Match(Expression &expr_p, vector<reference<Expression>> &bindings) override;
+};
+
+inline bool AggregateFunctionExpressionMatcher::Match(Expression &expr_p, vector<reference<Expression>> &bindings) {
+	if (!ExpressionMatcher::Match(expr_p, bindings)) {
+		return false;
+	}
+	auto &expr = expr_p.Cast<BoundAggregateExpression>();
+	if (!FunctionMatcher::Match(function, expr.function.name)) {
+		return false;
+	}
+	if (!SetMatcher::Match(matchers, expr.children, bindings, policy)) {
+		return false;
+	}
+	return true;
+}
+
+} // namespace duckdb

--- a/src/include/aggregate_function_matcher.hpp
+++ b/src/include/aggregate_function_matcher.hpp
@@ -7,7 +7,7 @@ namespace duckdb {
 class AggregateFunctionExpressionMatcher : public ExpressionMatcher {
 public:
 	AggregateFunctionExpressionMatcher()
-		: ExpressionMatcher(ExpressionClass::BOUND_AGGREGATE), policy(SetMatcher::Policy::INVALID) {
+	    : ExpressionMatcher(ExpressionClass::BOUND_AGGREGATE), policy(SetMatcher::Policy::INVALID) {
 	}
 	//! The matchers for the child expressions
 	vector<unique_ptr<ExpressionMatcher>> matchers;

--- a/src/include/hnsw/hnsw.hpp
+++ b/src/include/hnsw/hnsw.hpp
@@ -17,11 +17,13 @@ public:
 		RegisterExprOptimizer(db);
 		RegisterScanOptimizer(db);
 		RegisterTopKOptimizer(db);
+		RegisterJoinOptimizer(db);
 	}
 
 private:
 	static void RegisterIndex(DatabaseInstance &db);
 	static void RegisterIndexScan(DatabaseInstance &db);
+	static void RegisterMultiScan(DatabaseInstance &db);
 	static void RegisterIndexPragmas(DatabaseInstance &db);
 	static void RegisterPlanIndexCreate(DatabaseInstance &db);
 	static void RegisterMacros(DatabaseInstance &db);
@@ -30,6 +32,7 @@ private:
 	static void RegisterExprOptimizer(DatabaseInstance &db);
 	static void RegisterTopKOperator(DatabaseInstance &db);
 	static void RegisterScanOptimizer(DatabaseInstance &db);
+	static void RegisterJoinOptimizer(DatabaseInstance &db);
 };
 
 } // namespace duckdb

--- a/src/include/hnsw/hnsw_index.hpp
+++ b/src/include/hnsw/hnsw_index.hpp
@@ -3,14 +3,14 @@
 #include "duckdb/execution/index/bound_index.hpp"
 #include "duckdb/execution/index/index_pointer.hpp"
 #include "duckdb/execution/index/fixed_size_allocator.hpp"
-#include "duckdb/common/array.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
-#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/optimizer/matcher/expression_matcher.hpp"
 
 #include "usearch/duckdb_usearch.hpp"
 
 namespace duckdb {
 
+class FunctionExpressionMatcher;
 class StorageLock;
 
 struct HNSWIndexStats {
@@ -25,6 +25,7 @@ class HNSWIndex : public BoundIndex {
 public:
 	// The type name of the HNSWIndex
 	static constexpr const char *TYPE_NAME = "HNSW";
+	using USearchIndexType = unum::usearch::index_dense_gt<row_t>;
 
 public:
 	HNSWIndex(const string &name, IndexConstraintType index_constraint_type, const vector<column_t> &column_ids,
@@ -33,7 +34,7 @@ public:
 	          const IndexStorageInfo &info = IndexStorageInfo(), idx_t estimated_cardinality = 0);
 
 	//! The actual usearch index
-	unum::usearch::index_dense_gt<row_t> index;
+	USearchIndexType index;
 
 	//! Block pointer to the root of the index
 	IndexPointer root_block_ptr;
@@ -41,10 +42,14 @@ public:
 	//! The allocator used to persist linked blocks
 	unique_ptr<FixedSizeAllocator> linked_block_allocator;
 
+	unique_ptr<IndexScanState> InitializeMultiScan(ClientContext &context);
+	idx_t ExecuteMultiScan(IndexScanState &state, float *query_vector, idx_t limit);
+	const Vector& GetMultiScanResult(IndexScanState &state);
+	void ResetMultiScan(IndexScanState &state);
+
 	unique_ptr<IndexScanState> InitializeScan(float *query_vector, idx_t limit, ClientContext &context);
-	idx_t Scan(IndexScanState &state, Vector &result);
+	idx_t Scan(IndexScanState &state, Vector &result, idx_t result_offset = 0);
 	idx_t GetVectorSize() const;
-	bool MatchesDistanceFunction(const string &distance_function_name) const;
 	string GetMetric() const;
 
 	void Construct(DataChunk &input, Vector &row_ids, idx_t thread_idx);
@@ -55,6 +60,9 @@ public:
 
 	static const case_insensitive_map_t<unum::usearch::metric_kind_t> METRIC_KIND_MAP;
 	static const unordered_map<uint8_t, unum::usearch::scalar_kind_t> SCALAR_KIND_MAP;
+
+	bool TryMatchDistanceFunction(const unique_ptr<Expression>& expr, vector<reference<Expression>> &bindings) const;
+	bool TryBindIndexExpression(LogicalGet &get, unique_ptr<Expression> &result) const;
 
 public:
 	//! Called when data is appended to the index. The lock obtained from InitializeLock must be held
@@ -100,12 +108,12 @@ public:
 		index_size = index.size();
 	}
 
-	bool CanRewriteIndexExpression(LogicalGet &get, Expression &column_ref) const;
-
 private:
 	bool is_dirty = false;
 	StorageLock rwlock;
 	atomic<idx_t> index_size = {0};
+	unique_ptr<ExpressionMatcher> function_matcher;
+	unique_ptr<ExpressionMatcher> MakeFunctionMatcher() const;
 };
 
 } // namespace duckdb

--- a/src/include/hnsw/hnsw_index.hpp
+++ b/src/include/hnsw/hnsw_index.hpp
@@ -44,7 +44,7 @@ public:
 
 	unique_ptr<IndexScanState> InitializeMultiScan(ClientContext &context);
 	idx_t ExecuteMultiScan(IndexScanState &state, float *query_vector, idx_t limit);
-	const Vector& GetMultiScanResult(IndexScanState &state);
+	const Vector &GetMultiScanResult(IndexScanState &state);
 	void ResetMultiScan(IndexScanState &state);
 
 	unique_ptr<IndexScanState> InitializeScan(float *query_vector, idx_t limit, ClientContext &context);
@@ -61,7 +61,7 @@ public:
 	static const case_insensitive_map_t<unum::usearch::metric_kind_t> METRIC_KIND_MAP;
 	static const unordered_map<uint8_t, unum::usearch::scalar_kind_t> SCALAR_KIND_MAP;
 
-	bool TryMatchDistanceFunction(const unique_ptr<Expression>& expr, vector<reference<Expression>> &bindings) const;
+	bool TryMatchDistanceFunction(const unique_ptr<Expression> &expr, vector<reference<Expression>> &bindings) const;
 	bool TryBindIndexExpression(LogicalGet &get, unique_ptr<Expression> &result) const;
 
 public:

--- a/src/include/hnsw/hnsw_index.hpp
+++ b/src/include/hnsw/hnsw_index.hpp
@@ -43,7 +43,6 @@ public:
 
 	unique_ptr<IndexScanState> InitializeScan(float *query_vector, idx_t limit, ClientContext &context);
 	idx_t Scan(IndexScanState &state, Vector &result);
-
 	idx_t GetVectorSize() const;
 	bool MatchesDistanceFunction(const string &distance_function_name) const;
 	string GetMetric() const;

--- a/test/sql/hnsw/hnsw_join_macro.test
+++ b/test/sql/hnsw/hnsw_join_macro.test
@@ -10,6 +10,9 @@ statement ok
 CREATE TABLE s(s_vec FLOAT[3]);
 
 statement ok
+CREATE INDEX s_vec_idx ON t1 USING HNSW(vec);
+
+statement ok
 INSERT INTO s VALUES ([5,5,5]), ([1,1,1]);
 
 query I
@@ -17,8 +20,8 @@ SELECT bool_and(score <= 1.0) FROM vss_join(s, t1, s_vec, vec, 3) as res;
 ----
 true
 
-query I
-SELECT len(matches) = 3 FROM s, vss_match(t1, s_vec, vec, 3) as res;
-----
-true
-true
+#query I
+#SELECT len(matches) = 3 FROM s, vss_match(t1, s_vec, vec, 3) as res;
+#----
+#true
+#true

--- a/test/sql/hnsw/hnsw_join_macro.test
+++ b/test/sql/hnsw/hnsw_join_macro.test
@@ -15,13 +15,30 @@ CREATE INDEX s_vec_idx ON t1 USING HNSW(vec);
 statement ok
 INSERT INTO s VALUES ([5,5,5]), ([1,1,1]);
 
+statement ok
+pragma disable_optimizer;
+
 query I
 SELECT bool_and(score <= 1.0) FROM vss_join(s, t1, s_vec, vec, 3) as res;
 ----
 true
 
-#query I
-#SELECT len(matches) = 3 FROM s, vss_match(t1, s_vec, vec, 3) as res;
-#----
-#true
-#true
+query I
+SELECT len(matches) = 3 FROM s, vss_match(t1, s_vec, vec, 3) as res;
+----
+true
+true
+
+statement ok
+pragma enable_optimizer;
+
+query I
+SELECT bool_and(score <= 1.0) FROM vss_join(s, t1, s_vec, vec, 3) as res;
+----
+true
+
+query I
+SELECT len(matches) = 3 FROM s, vss_match(t1, s_vec, vec, 3) as res;
+----
+true
+true

--- a/test/sql/hnsw/hnsw_lateral_join.test
+++ b/test/sql/hnsw/hnsw_lateral_join.test
@@ -13,7 +13,7 @@ statement ok
 INSERT INTO b VALUES (ARRAY[4.0, 5.0, 6.0], 'b'), (ARRAY[1.0, 2.0, 3.0], 'a');
 
 statement ok
-CREATE INDEX my_idx ON a USING HNSW (a_vec);
+CREATE INDEX my_idx ON b USING HNSW (b_vec);
 
 query IIIII rowsort
 select * from a, lateral (select *, a_id as id_dup from b order by array_distance(a.a_vec, b.b_vec) limit 1);

--- a/test/sql/hnsw/hnsw_lateral_join.test
+++ b/test/sql/hnsw/hnsw_lateral_join.test
@@ -28,3 +28,40 @@ select * from a, lateral (select array_distance(a.a_vec, b.b_vec) as dist, *, a_
 ----
 [1.0, 2.0, 3.0]	1	0.0	[1.0, 2.0, 3.0]	a	1
 [4.0, 5.0, 6.0]	2	0.0	[4.0, 5.0, 6.0]	b	2
+
+# Higher limit, with nulls
+statement ok
+DROP INDEX my_idx;
+
+query IIIIII rowsort limit_2
+select * from a, lateral (select *, a_id as id_dup from b order by array_distance(a.a_vec, b.b_vec) limit 2);
+
+statement ok
+CREATE INDEX my_idx ON b USING HNSW (b_vec);
+
+query IIIIII rowsort limit_2
+select * from a, lateral (select *, a_id as id_dup from b order by array_distance(a.a_vec, b.b_vec) limit 2);
+
+statement ok
+INSERT INTO b VALUES (NULL, 'none');
+
+query IIIIII rowsort b_has_null
+select * from a, lateral (select *, a_id as id_dup from b order by array_distance(a.a_vec, b.b_vec) limit 2);
+
+statement ok
+DROP INDEX my_idx;
+
+query IIIIII rowsort b_has_null
+select * from a, lateral (select *, a_id as id_dup from b order by array_distance(a.a_vec, b.b_vec) limit 2);
+
+statement ok
+INSERT INTO a VALUES (NULL, 3);
+
+query IIIIII rowsort a_has_null
+select * from a, lateral (select *, a_id as id_dup from b order by array_distance(a.a_vec, b.b_vec) limit 2);
+
+statement ok
+CREATE INDEX my_idx ON b USING HNSW (b_vec);
+
+query IIIIII rowsort a_has_null
+select * from a, lateral (select *, a_id as id_dup from b order by array_distance(a.a_vec, b.b_vec) limit 2);

--- a/test/sql/hnsw/hnsw_lateral_join.test
+++ b/test/sql/hnsw/hnsw_lateral_join.test
@@ -1,0 +1,27 @@
+require vss
+
+statement ok
+CREATE TABLE a (a_vec FLOAT[3], a_id INT);
+
+statement ok
+CREATE TABLE b (b_vec FLOAT[3], b_str VARCHAR);
+
+statement ok
+INSERT INTO a VALUES (ARRAY[1.0, 2.0, 3.0], 1), (ARRAY[4.0, 5.0, 6.0], 2);
+
+statement ok
+INSERT INTO b VALUES (ARRAY[4.0, 5.0, 6.0], 'b'), (ARRAY[1.0, 2.0, 3.0], 'a');
+
+# Start with simple case (no extra projections)
+#query IIIII
+#select * from a, lateral (select * from b order by array_distance(a.a_vec, b.b_vec) limit 1);
+#----
+
+statement ok
+CREATE INDEX my_idx ON a USING HNSW (a_vec);
+
+query IIIII rowsort
+select * from a, lateral (select *, a_id as id_dup from b order by array_distance(a.a_vec, b.b_vec) limit 1);
+----
+[1.0, 2.0, 3.0]	1	[1.0, 2.0, 3.0]	a	1
+[4.0, 5.0, 6.0]	2	[4.0, 5.0, 6.0]	b	2

--- a/test/sql/hnsw/hnsw_lateral_join.test
+++ b/test/sql/hnsw/hnsw_lateral_join.test
@@ -12,11 +12,6 @@ INSERT INTO a VALUES (ARRAY[1.0, 2.0, 3.0], 1), (ARRAY[4.0, 5.0, 6.0], 2);
 statement ok
 INSERT INTO b VALUES (ARRAY[4.0, 5.0, 6.0], 'b'), (ARRAY[1.0, 2.0, 3.0], 'a');
 
-# Start with simple case (no extra projections)
-#query IIIII
-#select * from a, lateral (select * from b order by array_distance(a.a_vec, b.b_vec) limit 1);
-#----
-
 statement ok
 CREATE INDEX my_idx ON a USING HNSW (a_vec);
 
@@ -25,3 +20,11 @@ select * from a, lateral (select *, a_id as id_dup from b order by array_distanc
 ----
 [1.0, 2.0, 3.0]	1	[1.0, 2.0, 3.0]	a	1
 [4.0, 5.0, 6.0]	2	[4.0, 5.0, 6.0]	b	2
+
+
+# More advanced test, with additional projections
+query IIIIII rowsort
+select * from a, lateral (select array_distance(a.a_vec, b.b_vec) as dist, *, a_id as id_dup from b order by dist limit 1);
+----
+[1.0, 2.0, 3.0]	1	0.0	[1.0, 2.0, 3.0]	a	1
+[4.0, 5.0, 6.0]	2	0.0	[4.0, 5.0, 6.0]	b	2


### PR DESCRIPTION
This PR adds an optimizer rule to use the HNSW index to accelerate lateral vss joins, e.g. 

```sql
CREATE TABLE a (a_vec FLOAT[3], a_id INT);
CREATE TABLE b (b_vec FLOAT[3], b_str VARCHAR);

SELECT * FROM a, LATERAL (
  SELECT * FROM b ORDER BY array_distance(a.a_vec, b.b_vec) LIMIT 3
);
```

This enables "batch" index lookups by matching against a column of vectors instead of passing a single constant array value.

The optimization will apply for any constant value of `k` (e.g. what gets passed to inner `LIMIT` clause) up to DuckDB's `STANDARD_VECTOR_SIZE` (= 2048 by default).