### PR TITLE
Try to stabilize tests under address sanitizer in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,12 @@ PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 EXT_NAME=vss
 EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 
+# Stabilize all tests in CI
+ifdef CI
+TEST_FLAGS:=--stabilize-tests
+endif
+T ?= $(TEST_FLAGS) "test/*"
+
 # Include the Makefile from extension-ci-tools
 include extension-ci-tools/makefiles/duckdb_extension.Makefile
 


### PR DESCRIPTION
See related PR: https://github.com/duckdb/duckdb/pull/22904.

I want to repeatedly run extensions tests to detect (more) ASAN failures in CI. Some tests can fail "randomly" (if the right code paths are executed) and that affects duckdb CI on main and in PRs.

The extension author is not always aware of failure when bumping the extension in duckdb, and re-running tests should reduce the chance of merging code that fails once every ~ten runs.

I'm trying the new CLI flag `--stabilize-tests` in this extension first to see what we discover. It could be that we move the changes elsewhere (like `extension-ci-tools`).