### PR TITLE
Fix HNSW lateral-join optimizer for DuckDB 1.5+ (arg_min + delim_join_as_cte) and port to current main

### DIFF
--- a/src/hnsw/hnsw_index.cpp
+++ b/src/hnsw/hnsw_index.cpp
@@ -360,7 +360,9 @@ struct MultiScanState final : IndexScanState {
 	Vector vec;
 	vector<row_t> row_ids;
 	size_t ef_search;
-	MultiScanState(size_t ef_search_p) : vec(LogicalType::ROW_TYPE, nullptr), ef_search(ef_search_p) {
+	// NOTE: the vector must own a buffer: FlatVector::SetData (used in GetMultiScanResult)
+	// reads the existing buffer's validity mask, so a null-buffer vector crashes.
+	MultiScanState(size_t ef_search_p) : vec(LogicalType::ROW_TYPE), ef_search(ef_search_p) {
 	}
 };
 

--- a/src/hnsw/hnsw_index.cpp
+++ b/src/hnsw/hnsw_index.cpp
@@ -149,7 +149,7 @@ public:
 //------------------------------------------------------------------------------
 
 // Constructor
-HNSWIndex::HNSWIndex(const string &name, IndexConstraintType index_constraint_type, const vector<column_t> &column_ids,
+HNSWIndex::HNSWIndex(const Identifier &name, IndexConstraintType index_constraint_type, const vector<column_t> &column_ids,
                      TableIOManager &table_io_manager, const vector<unique_ptr<Expression>> &unbound_expressions,
                      AttachedDatabase &db, const case_insensitive_map_t<Value> &options, const IndexStorageInfo &info,
                      idx_t estimated_cardinality)
@@ -664,7 +664,7 @@ bool HNSWIndex::TryMatchDistanceFunction(Expression &expr,
 }
 
 unique_ptr<ExpressionMatcher> HNSWIndex::MakeFunctionMatcher() const {
-	unordered_set<string> distance_functions;
+	identifier_set_t distance_functions;
 	switch (index.metric().metric_kind()) {
 	case unum::usearch::metric_kind_t::l2sq_k:
 		distance_functions = {"array_distance", "<->"};

--- a/src/hnsw/hnsw_index_macros.cpp
+++ b/src/hnsw/hnsw_index_macros.cpp
@@ -86,17 +86,17 @@ static void RegisterTableMacro(ExtensionLoader &loader, const string &name, cons
 
 	auto func = make_uniq<TableMacroFunction>(std::move(node));
 	for (auto &param : params) {
-		func->parameters.push_back(make_uniq<ColumnRefExpression>(param));
+		func->parameters.push_back(make_uniq<ColumnRefExpression>(Identifier(param)));
 	}
 
 	for (auto &param : named_params) {
-		func->parameters.push_back(make_uniq<ColumnRefExpression>(param.first));
+		func->parameters.push_back(make_uniq<ColumnRefExpression>(Identifier(param.first)));
 		func->default_parameters[param.first] = make_uniq<ConstantExpression>(param.second);
 	}
 
 	CreateMacroInfo info(CatalogType::TABLE_MACRO_ENTRY);
 	info.schema = DEFAULT_SCHEMA;
-	info.name = name;
+	info.name = Identifier(name);
 	info.temporary = true;
 	info.internal = true;
 	info.macros.push_back(std::move(func));

--- a/src/hnsw/hnsw_index_plan.cpp
+++ b/src/hnsw/hnsw_index_plan.cpp
@@ -123,7 +123,7 @@ PhysicalOperator &HNSWIndex::CreatePlan(PlanIndexInput &input) {
 		auto is_not_null_expr =
 		    make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NOT_NULL, LogicalType::BOOLEAN);
 		auto bound_ref = make_uniq<BoundReferenceExpression>(new_column_types[i], i);
-		is_not_null_expr->children.push_back(std::move(bound_ref));
+		is_not_null_expr->GetChildrenMutable().push_back(std::move(bound_ref));
 		filter_select_list.push_back(std::move(is_not_null_expr));
 	}
 

--- a/src/hnsw/hnsw_index_scan.cpp
+++ b/src/hnsw/hnsw_index_scan.cpp
@@ -159,8 +159,8 @@ static InsertionOrderPreservingMap<string> HNSWIndexScanToString(TableFunctionTo
 	D_ASSERT(input.bind_data);
 	InsertionOrderPreservingMap<string> result;
 	auto &bind_data = input.bind_data->Cast<HNSWIndexScanBindData>();
-	result["Table"] = bind_data.table.name;
-	result["HNSW Index"] = bind_data.index.GetIndexName();
+	result["Table"] = bind_data.table.name.GetIdentifierName();
+	result["HNSW Index"] = bind_data.index.GetIndexName().GetIdentifierName();
 	return result;
 }
 

--- a/src/hnsw/hnsw_optimize_expr.cpp
+++ b/src/hnsw/hnsw_optimize_expr.cpp
@@ -46,14 +46,14 @@ unique_ptr<Expression> CosineDistanceRule::Apply(LogicalOperator &op, vector<ref
 	const auto &const_expr = bindings[1].get().Cast<BoundConstantExpression>();
 	auto &similarity_expr = bindings[2].get().Cast<BoundFunctionExpression>();
 
-	if (!const_expr.value.IsNull() && const_expr.value.GetValue<float>() == 1.0) {
+	if (!const_expr.GetValue().IsNull() && const_expr.GetValue().GetValue<float>() == 1.0) {
 		// Create the new array_cosine_distance function
 		vector<unique_ptr<Expression>> args;
 		vector<LogicalType> arg_types;
-		arg_types.push_back(similarity_expr.children[0]->GetReturnType());
-		arg_types.push_back(similarity_expr.children[1]->GetReturnType());
-		args.push_back(std::move(similarity_expr.children[0]));
-		args.push_back(std::move(similarity_expr.children[1]));
+		arg_types.push_back(similarity_expr.GetChildrenMutable()[0]->GetReturnType());
+		arg_types.push_back(similarity_expr.GetChildrenMutable()[1]->GetReturnType());
+		args.push_back(std::move(similarity_expr.GetChildrenMutable()[0]));
+		args.push_back(std::move(similarity_expr.GetChildrenMutable()[1]));
 
 		auto &context = GetContext();
 		auto func_entry = Catalog::GetEntry<ScalarFunctionCatalogEntry>(context, "", "", "array_cosine_distance",

--- a/src/hnsw/hnsw_optimize_join.cpp
+++ b/src/hnsw/hnsw_optimize_join.cpp
@@ -175,8 +175,8 @@ OperatorResultType PhysicalHNSWIndexJoin::Execute(ExecutionContext &context, Dat
 
 InsertionOrderPreservingMap<string> PhysicalHNSWIndexJoin::ParamsToString() const {
 	InsertionOrderPreservingMap<string> result;
-	auto table_name = table.name;
-	auto index_name = hnsw_index.name;
+	auto table_name = table.name.GetIdentifierName();
+	auto index_name = hnsw_index.name.GetIdentifierName();
 	result.insert("table", table_name);
 	result.insert("index", index_name);
 	result.insert("limit", to_string(limit));
@@ -333,6 +333,12 @@ public:
 	// arg_min top-k aggregate (TopNWindowElimination). This matches that plan shape.
 	static bool TryOptimizeArgMin(Binder &binder, ClientContext &context, unique_ptr<LogicalOperator> &root,
 	                              unique_ptr<LogicalOperator> &plan);
+	// DuckDB's `delim_join_as_cte` rewrite (default since the delim-join-as-CTE switch) turns the
+	// dependent join into a materialized CTE: the arg_min top-k subtree then hangs off an INNER
+	// comparison-join, fed by a CTE_SCAN of the correlated keys instead of a DELIM_GET. This matches
+	// that subtree and rewrites it to an HNSW_INDEX_JOIN over the correlated-key source.
+	static bool TryOptimizeArgMinCte(Binder &binder, ClientContext &context, unique_ptr<LogicalOperator> &root,
+	                                 unique_ptr<LogicalOperator> &plan);
 	static void OptimizeRecursive(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &root,
 	                              unique_ptr<LogicalOperator> &plan);
 	static void Optimize(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan);
@@ -464,7 +470,7 @@ bool HNSWIndexJoinOptimizer::TryOptimize(Binder &binder, ClientContext &context,
 	if (constant_expr.GetReturnType() != LogicalType::BIGINT) {
 		return false;
 	}
-	auto k_value = constant_expr.value.GetValue<int64_t>();
+	auto k_value = constant_expr.GetValue().GetValue<int64_t>();
 	if (k_value < 0 || k_value >= STANDARD_VECTOR_SIZE) {
 		// Can only optimize up to SVS
 		return false;
@@ -488,16 +494,16 @@ bool HNSWIndexJoinOptimizer::TryOptimize(Binder &binder, ClientContext &context,
 		return false;
 	}
 	auto &window_expr = window.expressions.back()->Cast<BoundWindowExpression>();
-	if (window_expr.orders.size() != 1) {
+	if (window_expr.OrderBy().size() != 1) {
 		return false;
 	}
-	if (window_expr.orders.back().type != OrderType::ASCENDING) {
+	if (window_expr.OrderBy().back().type != OrderType::ASCENDING) {
 		return false;
 	}
-	if (window_expr.orders.back().expression->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+	if (window_expr.OrderBy().back().expression->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
 		return false;
 	}
-	const auto &distance_ref_expr = window_expr.orders.back().expression->Cast<BoundColumnRefExpression>();
+	const auto &distance_ref_expr = window_expr.OrderBy().back().expression->Cast<BoundColumnRefExpression>();
 	// Verify that this column ref references the distance expression in the projection
 	if (distance_ref_expr.Binding().table_index != inner_proj.table_index) {
 		return false;
@@ -796,7 +802,7 @@ bool HNSWIndexJoinOptimizer::TryOptimizeArgMin(Binder &binder, ClientContext &co
 		if (agg_expr.GetChildren()[2]->GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
 			return false;
 		}
-		k_value = agg_expr.GetChildren()[2]->Cast<BoundConstantExpression>().value.GetValue<int64_t>();
+		k_value = agg_expr.GetChildren()[2]->Cast<BoundConstantExpression>().GetValue().GetValue<int64_t>();
 	}
 	if (k_value <= 0 || k_value >= STANDARD_VECTOR_SIZE) {
 		return false;
@@ -935,14 +941,14 @@ bool HNSWIndexJoinOptimizer::TryOptimizeArgMin(Binder &binder, ClientContext &co
 		}
 		if (e.GetExpressionType() == ExpressionType::BOUND_FUNCTION) {
 			auto &fexpr = e.Cast<BoundFunctionExpression>();
-			if (fexpr.function.GetName() == "struct_extract" && fexpr.children.size() == 2 &&
-			    fexpr.children[1]->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
-				const auto field = fexpr.children[1]->Cast<BoundConstantExpression>().value.ToString();
+			if (fexpr.Function().GetName() == "struct_extract" && fexpr.GetChildren().size() == 2 &&
+			    fexpr.GetChildren()[1]->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
+				const auto field = fexpr.GetChildren()[1]->Cast<BoundConstantExpression>().GetValue().ToString();
 				// The payload is a struct_pack; match the extracted field to a packed argument by name.
 				if (agg_expr.GetChildren()[0]->GetExpressionType() == ExpressionType::BOUND_FUNCTION) {
 					auto &pack = agg_expr.GetChildren()[0]->Cast<BoundFunctionExpression>();
-					if (pack.function.GetName() == "struct_pack") {
-						for (auto &arg : pack.children) {
+					if (pack.Function().GetName() == "struct_pack") {
+						for (auto &arg : pack.GetChildren()) {
 							if (arg->ToString() == field) {
 								return resolve_expr(*arg);
 							}
@@ -1107,10 +1113,386 @@ bool HNSWIndexJoinOptimizer::TryOptimizeArgMin(Binder &binder, ClientContext &co
 	return true;
 }
 
+bool HNSWIndexJoinOptimizer::TryOptimizeArgMinCte(Binder &binder, ClientContext &context,
+                                                  unique_ptr<LogicalOperator> &root,
+                                                  unique_ptr<LogicalOperator> &plan) {
+	//------------------------------------------------------------------------------
+	// Match the DuckDB delim_join_as_cte plan. The dependent join is materialised as
+	// a CTE, and the arg_min top-k subtree appears as one side of an INNER comparison
+	// join, with the correlated keys arriving through a CTE_SCAN instead of a
+	// DELIM_GET:
+	//
+	//   projection(s) / [unnest]                          <- `plan` (anchor)
+	//     -> aggregate  arg_min(payload, distance, [k]) group by <corr>
+	//       -> projection "inner" (computes the distance)
+	//         -> cross_product
+	//           -> get (rhs, seq_scan, indexed)
+	//           -> corr_source (... -> cte_ref)            (correlated keys)
+	//
+	// We replace this subtree with an HNSW_INDEX_JOIN whose child is corr_source. The
+	// surrounding CTE / comparison-join (which re-attaches the per-key result to the
+	// outer rows) is left intact. The plain DELIM_JOIN shape is handled higher up by
+	// TryOptimizeArgMin, so this only ever fires on the CTE rewrite.
+	//------------------------------------------------------------------------------
+
+	// Walk down the projection/unnest chain to the aggregate.
+	vector<reference<LogicalOperator>> corr_chain;
+	LogicalOperator *cursor = plan.get();
+	while (cursor && cursor->type != LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY) {
+		if ((cursor->type != LogicalOperatorType::LOGICAL_PROJECTION &&
+		     cursor->type != LogicalOperatorType::LOGICAL_UNNEST) ||
+		    cursor->children.size() != 1) {
+			return false;
+		}
+		corr_chain.push_back(*cursor);
+		cursor = cursor->children[0].get();
+	}
+	if (!cursor) {
+		return false;
+	}
+	auto &aggregate = cursor->Cast<LogicalAggregate>();
+
+	// A single arg_min aggregate over a single group (the correlation key).
+	if (aggregate.expressions.size() != 1 || aggregate.groups.size() != 1) {
+		return false;
+	}
+	if (aggregate.expressions[0]->GetExpressionType() != ExpressionType::BOUND_AGGREGATE) {
+		return false;
+	}
+	auto &agg_expr = aggregate.expressions[0]->Cast<BoundAggregateExpression>();
+	const auto agg_name = agg_expr.Function().GetName();
+	if (agg_name != "arg_min_nulls_last" && agg_name != "arg_min" && agg_name != "min_by") {
+		return false;
+	}
+	if (agg_expr.GetChildren().size() < 2 || agg_expr.GetChildren().size() > 3) {
+		return false;
+	}
+
+	int64_t k_value = 1;
+	if (agg_expr.GetChildren().size() == 3) {
+		if (agg_expr.GetChildren()[2]->GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
+			return false;
+		}
+		k_value = agg_expr.GetChildren()[2]->Cast<BoundConstantExpression>().GetValue().GetValue<int64_t>();
+	}
+	if (k_value <= 0 || k_value >= STANDARD_VECTOR_SIZE) {
+		return false;
+	}
+
+	if (agg_expr.GetChildren()[1]->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+		return false;
+	}
+	auto &order_ref = agg_expr.GetChildren()[1]->Cast<BoundColumnRefExpression>();
+
+	// inner_proj -> cross_product -> {get (seq_scan), corr_source}
+	if (aggregate.children.size() != 1 ||
+	    aggregate.children[0]->type != LogicalOperatorType::LOGICAL_PROJECTION) {
+		return false;
+	}
+	auto &inner_proj = aggregate.children[0]->Cast<LogicalProjection>();
+	if (inner_proj.children.size() != 1 ||
+	    inner_proj.children[0]->type != LogicalOperatorType::LOGICAL_CROSS_PRODUCT) {
+		return false;
+	}
+	auto &cross_product = inner_proj.children[0]->Cast<LogicalCrossProduct>();
+
+	// One side of the cross product is the indexed seq_scan, the other is the
+	// correlated-key source (a CTE_SCAN-rooted subtree, not a DELIM_GET).
+	auto &cp_lhs = cross_product.children[0];
+	auto &cp_rhs = cross_product.children[1];
+	unique_ptr<LogicalOperator> *corr_source_ptr = nullptr;
+	unique_ptr<LogicalOperator> *inner_get_ptr = nullptr;
+	if (cp_lhs->type == LogicalOperatorType::LOGICAL_GET &&
+	    cp_lhs->Cast<LogicalGet>().function.name == "seq_scan") {
+		inner_get_ptr = &cp_lhs;
+		corr_source_ptr = &cp_rhs;
+	} else if (cp_rhs->type == LogicalOperatorType::LOGICAL_GET &&
+	           cp_rhs->Cast<LogicalGet>().function.name == "seq_scan") {
+		inner_get_ptr = &cp_rhs;
+		corr_source_ptr = &cp_lhs;
+	} else {
+		return false;
+	}
+	auto &inner_get = (*inner_get_ptr)->Cast<LogicalGet>();
+	auto &corr_source = **corr_source_ptr;
+	// The DELIM_GET shape belongs to TryOptimizeArgMin; only fire for the CTE rewrite.
+	if (corr_source.type == LogicalOperatorType::LOGICAL_DELIM_GET) {
+		return false;
+	}
+	std::function<bool(LogicalOperator &)> has_cte_ref = [&](LogicalOperator &op) -> bool {
+		if (op.type == LogicalOperatorType::LOGICAL_CTE_REF) {
+			return true;
+		}
+		for (auto &c : op.children) {
+			if (has_cte_ref(*c)) {
+				return true;
+			}
+		}
+		return false;
+	};
+	if (!has_cte_ref(corr_source)) {
+		return false;
+	}
+
+	// The distance expression lives in inner_proj, referenced by the order argument.
+	const auto inner_proj_bindings = inner_proj.GetColumnBindings();
+	bool order_in_inner_proj = false;
+	for (auto &b : inner_proj_bindings) {
+		if (b == order_ref.Binding()) {
+			order_in_inner_proj = true;
+			break;
+		}
+	}
+	if (!order_in_inner_proj || order_ref.Binding().column_index >= inner_proj.expressions.size()) {
+		return false;
+	}
+	auto &distance_expr_ptr = *inner_proj.expressions[order_ref.Binding().column_index];
+
+	//------------------------------------------------------------------------------
+	// Match the index (identical to the other matchers).
+	//------------------------------------------------------------------------------
+	auto &table = *inner_get.GetTable();
+	if (!table.IsDuckTable()) {
+		return false;
+	}
+	auto &duck_table = table.Cast<DuckTableEntry>();
+	auto &table_info = *table.GetStorage().GetDataTableInfo();
+
+	HNSWIndex *index_ptr = nullptr;
+	vector<reference<Expression>> bindings;
+
+	table_info.BindIndexes(context, HNSWIndex::TYPE_NAME);
+	for (auto &index : table_info.GetIndexes().Indexes()) {
+		if (!index.IsBound() || HNSWIndex::TYPE_NAME != index.GetIndexType()) {
+			continue;
+		}
+		auto &cast_index = index.Cast<HNSWIndex>();
+		bindings.clear();
+		if (!cast_index.TryMatchDistanceFunction(distance_expr_ptr, bindings)) {
+			continue;
+		}
+		unique_ptr<Expression> bound_index_expr = nullptr;
+		if (!cast_index.TryBindIndexExpression(inner_get, bound_index_expr)) {
+			continue;
+		}
+		auto &lhs_dist_expr = bindings[1];
+		auto &rhs_dist_expr = bindings[2];
+		if (lhs_dist_expr.get().Equals(*bound_index_expr)) {
+			if (!rhs_dist_expr.get().Equals(*bound_index_expr)) {
+				std::swap(lhs_dist_expr, rhs_dist_expr);
+			} else {
+				return false;
+			}
+		}
+		index_ptr = &cast_index;
+		break;
+	}
+	if (!index_ptr) {
+		return false;
+	}
+	if (bindings[1].get().GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+		return false;
+	}
+	if (bindings[2].get().GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+		return false;
+	}
+	const auto &outer_ref_expr = bindings[1].get().Cast<BoundColumnRefExpression>();
+	const auto &inner_ref_expr = bindings[2].get().Cast<BoundColumnRefExpression>();
+	if (inner_ref_expr.Binding().table_index != inner_get.table_index) {
+		return false;
+	}
+
+	// The query vector must be a column of corr_source (the index join's child).
+	const auto corr_bindings = corr_source.GetColumnBindings();
+	bool outer_in_corr = false;
+	for (auto &b : corr_bindings) {
+		if (b == outer_ref_expr.Binding()) {
+			outer_in_corr = true;
+			break;
+		}
+	}
+	if (!outer_in_corr) {
+		return false;
+	}
+
+	//------------------------------------------------------------------------------
+	// Resolver: corr_source plays both the OUTER and DELIM roles.
+	//------------------------------------------------------------------------------
+	const auto inner_get_bindings = inner_get.GetColumnBindings();
+	const auto &delim_get_bindings = corr_bindings;
+	const auto &outer_get_bindings = corr_bindings;
+	const auto agg_bindings = aggregate.GetColumnBindings();
+
+	std::function<ArgMinOrigin(const ColumnBinding &)> resolve;
+	std::function<ArgMinOrigin(Expression &)> resolve_expr;
+
+	resolve_expr = [&](Expression &e) -> ArgMinOrigin {
+		if (e.GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
+			return resolve(e.Cast<BoundColumnRefExpression>().Binding());
+		}
+		if (e.GetExpressionType() == ExpressionType::BOUND_FUNCTION) {
+			auto &fexpr = e.Cast<BoundFunctionExpression>();
+			if (fexpr.Function().GetName() == "struct_extract" && fexpr.GetChildren().size() == 2 &&
+			    fexpr.GetChildren()[1]->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
+				const auto field = fexpr.GetChildren()[1]->Cast<BoundConstantExpression>().GetValue().ToString();
+				if (agg_expr.GetChildren()[0]->GetExpressionType() == ExpressionType::BOUND_FUNCTION) {
+					auto &pack = agg_expr.GetChildren()[0]->Cast<BoundFunctionExpression>();
+					if (pack.Function().GetName() == "struct_pack") {
+						for (auto &arg : pack.GetChildren()) {
+							if (arg->ToString() == field) {
+								return resolve_expr(*arg);
+							}
+						}
+					}
+				}
+				return {ArgMinOrigin::Kind::UNKNOWN, {}};
+			}
+			return {ArgMinOrigin::Kind::DISTANCE, {}};
+		}
+		return {ArgMinOrigin::Kind::UNKNOWN, {}};
+	};
+
+	resolve = [&](const ColumnBinding &b) -> ArgMinOrigin {
+		for (auto &ib : inner_get_bindings) {
+			if (ib == b) {
+				return {ArgMinOrigin::Kind::INNER, b};
+			}
+		}
+		for (auto &db : delim_get_bindings) {
+			if (db == b) {
+				return {ArgMinOrigin::Kind::DELIM, b};
+			}
+		}
+		for (auto &ob : outer_get_bindings) {
+			if (ob == b) {
+				return {ArgMinOrigin::Kind::OUTER, b};
+			}
+		}
+		for (idx_t i = 0; i < inner_proj_bindings.size(); i++) {
+			if (inner_proj_bindings[i] == b) {
+				return resolve_expr(*inner_proj.expressions[i]);
+			}
+		}
+		for (idx_t i = 0; i < aggregate.groups.size() && i < agg_bindings.size(); i++) {
+			if (agg_bindings[i] == b) {
+				return resolve_expr(*aggregate.groups[i]);
+			}
+		}
+		for (idx_t i = aggregate.groups.size(); i < agg_bindings.size(); i++) {
+			if (agg_bindings[i] == b) {
+				return resolve_expr(*agg_expr.GetChildren()[0]);
+			}
+		}
+		for (auto &op_ref : corr_chain) {
+			auto &op = op_ref.get();
+			if (op.type == LogicalOperatorType::LOGICAL_PROJECTION) {
+				auto &proj = op.Cast<LogicalProjection>();
+				auto pbindings = proj.GetColumnBindings();
+				for (idx_t i = 0; i < pbindings.size(); i++) {
+					if (pbindings[i] == b) {
+						return resolve_expr(*proj.expressions[i]);
+					}
+				}
+			} else if (op.type == LogicalOperatorType::LOGICAL_UNNEST) {
+				auto ubindings = op.GetColumnBindings();
+				auto child_bindings = op.children[0]->GetColumnBindings();
+				for (auto &ub : ubindings) {
+					if (!(ub == b)) {
+						continue;
+					}
+					bool passthrough = false;
+					for (auto &cb : child_bindings) {
+						if (cb == b) {
+							passthrough = true;
+							break;
+						}
+					}
+					if (!passthrough) {
+						return resolve_expr(*agg_expr.GetChildren()[0]);
+					}
+				}
+			}
+		}
+		return {ArgMinOrigin::Kind::UNKNOWN, {}};
+	};
+
+	//------------------------------------------------------------------------------
+	// Build the HNSW index join, child = corr_source (correlated keys).
+	//------------------------------------------------------------------------------
+	auto index_join = make_uniq<LogicalHNSWIndexJoin>(binder.GenerateTableIndex(), duck_table, *index_ptr, k_value);
+	for (auto &column_id : inner_get.GetColumnIds()) {
+		index_join->inner_column_ids.emplace_back(column_id.GetPrimaryIndex());
+	}
+	index_join->inner_projection_ids = inner_get.projection_ids;
+	index_join->inner_returned_types = inner_get.returned_types;
+	index_join->outer_vector_column = outer_ref_expr.Binding().column_index;
+	index_join->inner_vector_column = inner_ref_expr.Binding().column_index;
+
+	ColumnBindingReplacer replacer;
+
+	// Reproduce the subtree's output columns (the comparison-join's input) in terms of
+	// the index join / corr_source. Resolve every output column up front so an
+	// unrecognised shape leaves the plan untouched.
+	auto output_bindings = plan->GetColumnBindings();
+	auto output_types = plan->types;
+	vector<ArgMinOrigin> origins;
+	origins.reserve(output_bindings.size());
+	for (auto &ob : output_bindings) {
+		auto origin = resolve(ob);
+		if (origin.kind == ArgMinOrigin::Kind::UNKNOWN) {
+			return false;
+		}
+		origins.push_back(origin);
+	}
+
+	vector<unique_ptr<Expression>> projection_expressions;
+	auto projection_table_index = binder.GenerateTableIndex();
+	ProjectionIndex new_binding_idx(0);
+	for (idx_t i = 0; i < output_bindings.size(); i++) {
+		if (origins[i].kind == ArgMinOrigin::Kind::DISTANCE) {
+			// The index join does not materialise the distance; recompute it. The copy
+			// references the inner_get / corr_source and is remapped below.
+			projection_expressions.push_back(distance_expr_ptr.Copy());
+		} else {
+			// OUTER/DELIM origins reference corr_source columns, which pass through the
+			// index join unchanged; INNER origins are remapped to the index join below.
+			projection_expressions.push_back(
+			    make_uniq<BoundColumnRefExpression>(output_types[i], origins[i].binding));
+		}
+		replacer.replacement_bindings.emplace_back(output_bindings[i],
+		                                           ColumnBinding(projection_table_index, new_binding_idx++));
+	}
+	auto new_projection = make_uniq<LogicalProjection>(projection_table_index, std::move(projection_expressions));
+
+	// Redirect all references to the subtree's outputs to the new projection.
+	replacer.VisitOperator(*root);
+	replacer.replacement_bindings.clear();
+
+	// Everything that used to reference the inner get now references the index join.
+	for (const auto &old_binding : inner_get.GetColumnBindings()) {
+		replacer.replacement_bindings.emplace_back(old_binding,
+		                                           ColumnBinding(index_join->table_index, old_binding.column_index));
+	}
+	replacer.VisitOperator(*new_projection);
+
+	// Assemble: index join takes corr_source as its (only) child, new projection on top.
+	index_join->children.emplace_back(std::move(*corr_source_ptr));
+	new_projection->children.emplace_back(std::move(index_join));
+	new_projection->EstimateCardinality(context);
+
+	plan = std::move(new_projection);
+
+	CardinalityResetter cardinality_resetter(context);
+	cardinality_resetter.VisitOperator(*root);
+
+	return true;
+}
+
 void HNSWIndexJoinOptimizer::OptimizeRecursive(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &root,
                                                unique_ptr<LogicalOperator> &plan) {
 	if (!TryOptimize(input.optimizer.binder, input.context, root, plan) &&
-	    !TryOptimizeArgMin(input.optimizer.binder, input.context, root, plan)) {
+	    !TryOptimizeArgMin(input.optimizer.binder, input.context, root, plan) &&
+	    !TryOptimizeArgMinCte(input.optimizer.binder, input.context, root, plan)) {
 		// Recursively optimize the children
 		for (auto &child : plan->children) {
 			OptimizeRecursive(input, root, child);

--- a/src/hnsw/hnsw_optimize_join.cpp
+++ b/src/hnsw/hnsw_optimize_join.cpp
@@ -3,9 +3,12 @@
 #include "duckdb/optimizer/column_binding_replacer.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/optimizer/optimizer_extension.hpp"
+#include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_window_expression.hpp"
+#include "duckdb/planner/operator/logical_aggregate.hpp"
 #include "duckdb/planner/operator/logical_cross_product.hpp"
 #include "duckdb/planner/operator/logical_delim_get.hpp"
 #include "duckdb/planner/operator/logical_extension_operator.hpp"
@@ -326,6 +329,10 @@ public:
 	HNSWIndexJoinOptimizer();
 	static bool TryOptimize(Binder &binder, ClientContext &context, unique_ptr<LogicalOperator> &root,
 	                        unique_ptr<LogicalOperator> &plan);
+	// DuckDB >= 1.5 rewrites the `ORDER BY distance LIMIT k` window/filter pattern into an
+	// arg_min top-k aggregate (TopNWindowElimination). This matches that plan shape.
+	static bool TryOptimizeArgMin(Binder &binder, ClientContext &context, unique_ptr<LogicalOperator> &root,
+	                              unique_ptr<LogicalOperator> &plan);
 	static void OptimizeRecursive(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &root,
 	                              unique_ptr<LogicalOperator> &plan);
 	static void Optimize(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan);
@@ -699,9 +706,411 @@ bool HNSWIndexJoinOptimizer::TryOptimize(Binder &binder, ClientContext &context,
 	return true;
 }
 
+// Origin of a column produced by the correlated subtree, traced back to the
+// physical relation the HNSW index join will expose.
+namespace {
+struct ArgMinOrigin {
+	enum class Kind { INNER, DELIM, OUTER, DISTANCE, UNKNOWN };
+	Kind kind = Kind::UNKNOWN;
+	ColumnBinding binding;
+};
+} // namespace
+
+bool HNSWIndexJoinOptimizer::TryOptimizeArgMin(Binder &binder, ClientContext &context,
+                                               unique_ptr<LogicalOperator> &root,
+                                               unique_ptr<LogicalOperator> &plan) {
+	//------------------------------------------------------------------------------
+	// Match the DuckDB >= 1.5 plan produced by TopNWindowElimination:
+	//
+	// delim_join
+	//   -> get (outer/lhs)                              [either child]
+	//   -> projection(s)
+	//        -> [unnest]                                (only when k > 1)
+	//          -> aggregate  arg_min(payload, distance, [k]) group by <corr>
+	//            -> projection "inner" (computes the distance)
+	//              -> cross_product
+	//                -> delim_get
+	//                -> get (rhs, seq_scan, indexed)
+	//------------------------------------------------------------------------------
+
+	if (plan->type != LogicalOperatorType::LOGICAL_DELIM_JOIN || plan->children.size() != 2) {
+		return false;
+	}
+	auto &delim_join = plan->Cast<LogicalJoin>();
+
+	// The outer side is a bare GET; the other side is the correlated subtree. In
+	// DuckDB <= 1.4 the GET was children[1]; in >= 1.5 it is children[0].
+	unique_ptr<LogicalOperator> *outer_get_ptr = nullptr;
+	unique_ptr<LogicalOperator> *corr_ptr = nullptr;
+	for (idx_t i = 0; i < 2; i++) {
+		if (delim_join.children[i]->type == LogicalOperatorType::LOGICAL_GET &&
+		    delim_join.children[i]->children.empty()) {
+			outer_get_ptr = &delim_join.children[i];
+			corr_ptr = &delim_join.children[1 - i];
+			break;
+		}
+	}
+	if (!outer_get_ptr) {
+		return false;
+	}
+	auto &outer_get = (*outer_get_ptr)->Cast<LogicalGet>();
+
+	// Walk down the correlated side, collecting the projection/unnest chain until
+	// we reach the aggregate.
+	vector<reference<LogicalOperator>> corr_chain;
+	LogicalOperator *cursor = corr_ptr->get();
+	while (cursor && cursor->type != LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY) {
+		if ((cursor->type != LogicalOperatorType::LOGICAL_PROJECTION &&
+		     cursor->type != LogicalOperatorType::LOGICAL_UNNEST) ||
+		    cursor->children.size() != 1) {
+			return false;
+		}
+		corr_chain.push_back(*cursor);
+		cursor = cursor->children[0].get();
+	}
+	if (!cursor) {
+		return false;
+	}
+	auto &aggregate = cursor->Cast<LogicalAggregate>();
+
+	// A single arg_min aggregate over a single group (the correlation key).
+	if (aggregate.expressions.size() != 1 || aggregate.groups.size() != 1) {
+		return false;
+	}
+	if (aggregate.expressions[0]->GetExpressionType() != ExpressionType::BOUND_AGGREGATE) {
+		return false;
+	}
+	auto &agg_expr = aggregate.expressions[0]->Cast<BoundAggregateExpression>();
+	const auto agg_name = agg_expr.Function().GetName();
+	// Only the "min" variants give nearest-neighbours (ascending distance).
+	if (agg_name != "arg_min_nulls_last" && agg_name != "arg_min" && agg_name != "min_by") {
+		return false;
+	}
+	if (agg_expr.GetChildren().size() < 2 || agg_expr.GetChildren().size() > 3) {
+		return false;
+	}
+
+	// k is the optional 3rd argument; absent means LIMIT 1.
+	int64_t k_value = 1;
+	if (agg_expr.GetChildren().size() == 3) {
+		if (agg_expr.GetChildren()[2]->GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
+			return false;
+		}
+		k_value = agg_expr.GetChildren()[2]->Cast<BoundConstantExpression>().value.GetValue<int64_t>();
+	}
+	if (k_value <= 0 || k_value >= STANDARD_VECTOR_SIZE) {
+		return false;
+	}
+
+	// The order argument (children[1]) is a reference to the distance column in inner_proj.
+	if (agg_expr.GetChildren()[1]->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+		return false;
+	}
+	auto &order_ref = agg_expr.GetChildren()[1]->Cast<BoundColumnRefExpression>();
+
+	// inner_proj -> cross_product -> {delim_get, get}
+	if (aggregate.children.size() != 1 ||
+	    aggregate.children[0]->type != LogicalOperatorType::LOGICAL_PROJECTION) {
+		return false;
+	}
+	auto &inner_proj = aggregate.children[0]->Cast<LogicalProjection>();
+	if (inner_proj.children.size() != 1 ||
+	    inner_proj.children[0]->type != LogicalOperatorType::LOGICAL_CROSS_PRODUCT) {
+		return false;
+	}
+	auto &cross_product = inner_proj.children[0]->Cast<LogicalCrossProduct>();
+
+	unique_ptr<LogicalOperator> *delim_get_ptr = nullptr;
+	unique_ptr<LogicalOperator> *inner_get_ptr = nullptr;
+	auto &cp_lhs = cross_product.children[0];
+	auto &cp_rhs = cross_product.children[1];
+	if (cp_lhs->type == LogicalOperatorType::LOGICAL_DELIM_GET && cp_rhs->type == LogicalOperatorType::LOGICAL_GET) {
+		delim_get_ptr = &cp_lhs;
+		inner_get_ptr = &cp_rhs;
+	} else if (cp_rhs->type == LogicalOperatorType::LOGICAL_DELIM_GET &&
+	           cp_lhs->type == LogicalOperatorType::LOGICAL_GET) {
+		delim_get_ptr = &cp_rhs;
+		inner_get_ptr = &cp_lhs;
+	} else {
+		return false;
+	}
+	auto &delim_get = (*delim_get_ptr)->Cast<LogicalDelimGet>();
+	auto &inner_get = (*inner_get_ptr)->Cast<LogicalGet>();
+	if (inner_get.function.name != "seq_scan") {
+		return false;
+	}
+
+	// The distance expression lives in inner_proj, referenced by the order argument.
+	const auto inner_proj_bindings = inner_proj.GetColumnBindings();
+	bool order_in_inner_proj = false;
+	for (auto &b : inner_proj_bindings) {
+		if (b == order_ref.Binding()) {
+			order_in_inner_proj = true;
+			break;
+		}
+	}
+	if (!order_in_inner_proj || order_ref.Binding().column_index >= inner_proj.expressions.size()) {
+		return false;
+	}
+	auto &distance_expr_ptr = *inner_proj.expressions[order_ref.Binding().column_index];
+
+	//------------------------------------------------------------------------------
+	// Match the index (identical to the window-plan matcher).
+	//------------------------------------------------------------------------------
+	auto &table = *inner_get.GetTable();
+	if (!table.IsDuckTable()) {
+		return false;
+	}
+	auto &duck_table = table.Cast<DuckTableEntry>();
+	auto &table_info = *table.GetStorage().GetDataTableInfo();
+
+	HNSWIndex *index_ptr = nullptr;
+	vector<reference<Expression>> bindings;
+
+	table_info.BindIndexes(context, HNSWIndex::TYPE_NAME);
+	for (auto &index : table_info.GetIndexes().Indexes()) {
+		if (!index.IsBound() || HNSWIndex::TYPE_NAME != index.GetIndexType()) {
+			continue;
+		}
+		auto &cast_index = index.Cast<HNSWIndex>();
+		bindings.clear();
+		if (!cast_index.TryMatchDistanceFunction(distance_expr_ptr, bindings)) {
+			continue;
+		}
+		unique_ptr<Expression> bound_index_expr = nullptr;
+		if (!cast_index.TryBindIndexExpression(inner_get, bound_index_expr)) {
+			continue;
+		}
+		ExpressionIterator::EnumerateExpression(bound_index_expr, [&](Expression &child) {
+			if (child.GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
+				auto &bound_colref_expr = child.Cast<BoundColumnRefExpression>();
+				if (bound_colref_expr.Binding().table_index == outer_get.table_index) {
+					bound_colref_expr.BindingMutable().table_index = delim_get.table_index;
+				}
+			}
+		});
+		auto &lhs_dist_expr = bindings[1];
+		auto &rhs_dist_expr = bindings[2];
+		if (lhs_dist_expr.get().Equals(*bound_index_expr)) {
+			if (!rhs_dist_expr.get().Equals(*bound_index_expr)) {
+				std::swap(lhs_dist_expr, rhs_dist_expr);
+			} else {
+				return false;
+			}
+		}
+		index_ptr = &cast_index;
+		break;
+	}
+	if (!index_ptr) {
+		return false;
+	}
+	if (bindings[1].get().GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+		return false;
+	}
+	if (bindings[2].get().GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+		return false;
+	}
+	const auto &outer_ref_expr = bindings[1].get().Cast<BoundColumnRefExpression>();
+	const auto &inner_ref_expr = bindings[2].get().Cast<BoundColumnRefExpression>();
+	if (inner_ref_expr.Binding().table_index != inner_get.table_index) {
+		return false;
+	}
+
+	//------------------------------------------------------------------------------
+	// Resolver: trace a column produced by the correlated subtree down to the
+	// inner table column (INNER), the correlation column (DELIM), the outer table
+	// (OUTER) or the distance expression (DISTANCE).
+	//------------------------------------------------------------------------------
+	const auto inner_get_bindings = inner_get.GetColumnBindings();
+	const auto delim_get_bindings = delim_get.GetColumnBindings();
+	const auto outer_get_bindings = outer_get.GetColumnBindings();
+	const auto agg_bindings = aggregate.GetColumnBindings();
+
+	std::function<ArgMinOrigin(const ColumnBinding &)> resolve;
+	std::function<ArgMinOrigin(Expression &)> resolve_expr;
+
+	resolve_expr = [&](Expression &e) -> ArgMinOrigin {
+		if (e.GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
+			return resolve(e.Cast<BoundColumnRefExpression>().Binding());
+		}
+		if (e.GetExpressionType() == ExpressionType::BOUND_FUNCTION) {
+			auto &fexpr = e.Cast<BoundFunctionExpression>();
+			if (fexpr.function.GetName() == "struct_extract" && fexpr.children.size() == 2 &&
+			    fexpr.children[1]->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
+				const auto field = fexpr.children[1]->Cast<BoundConstantExpression>().value.ToString();
+				// The payload is a struct_pack; match the extracted field to a packed argument by name.
+				if (agg_expr.GetChildren()[0]->GetExpressionType() == ExpressionType::BOUND_FUNCTION) {
+					auto &pack = agg_expr.GetChildren()[0]->Cast<BoundFunctionExpression>();
+					if (pack.function.GetName() == "struct_pack") {
+						for (auto &arg : pack.children) {
+							if (arg->ToString() == field) {
+								return resolve_expr(*arg);
+							}
+						}
+					}
+				}
+				return {ArgMinOrigin::Kind::UNKNOWN, {}};
+			}
+			// Any other function (e.g. array_distance) is treated as the distance.
+			return {ArgMinOrigin::Kind::DISTANCE, {}};
+		}
+		return {ArgMinOrigin::Kind::UNKNOWN, {}};
+	};
+
+	resolve = [&](const ColumnBinding &b) -> ArgMinOrigin {
+		for (auto &ib : inner_get_bindings) {
+			if (ib == b) {
+				return {ArgMinOrigin::Kind::INNER, b};
+			}
+		}
+		for (auto &db : delim_get_bindings) {
+			if (db == b) {
+				return {ArgMinOrigin::Kind::DELIM, b};
+			}
+		}
+		for (auto &ob : outer_get_bindings) {
+			if (ob == b) {
+				return {ArgMinOrigin::Kind::OUTER, b};
+			}
+		}
+		// inner_proj
+		for (idx_t i = 0; i < inner_proj_bindings.size(); i++) {
+			if (inner_proj_bindings[i] == b) {
+				return resolve_expr(*inner_proj.expressions[i]);
+			}
+		}
+		// aggregate: group columns first, then the (single) aggregate result.
+		for (idx_t i = 0; i < aggregate.groups.size() && i < agg_bindings.size(); i++) {
+			if (agg_bindings[i] == b) {
+				return resolve_expr(*aggregate.groups[i]);
+			}
+		}
+		for (idx_t i = aggregate.groups.size(); i < agg_bindings.size(); i++) {
+			if (agg_bindings[i] == b) {
+				// Single-column payload: resolve the packed expression directly.
+				return resolve_expr(*agg_expr.GetChildren()[0]);
+			}
+		}
+		// projections / unnest along the correlated chain.
+		for (auto &op_ref : corr_chain) {
+			auto &op = op_ref.get();
+			if (op.type == LogicalOperatorType::LOGICAL_PROJECTION) {
+				auto &proj = op.Cast<LogicalProjection>();
+				auto pbindings = proj.GetColumnBindings();
+				for (idx_t i = 0; i < pbindings.size(); i++) {
+					if (pbindings[i] == b) {
+						return resolve_expr(*proj.expressions[i]);
+					}
+				}
+			} else if (op.type == LogicalOperatorType::LOGICAL_UNNEST) {
+				// The UNNEST flattens the arg_min top-k list. Passthrough columns are
+				// resolved via the aggregate above; the newly produced (unnested) column
+				// is one element of the list, i.e. the aggregate payload.
+				auto ubindings = op.GetColumnBindings();
+				auto child_bindings = op.children[0]->GetColumnBindings();
+				for (auto &ub : ubindings) {
+					if (!(ub == b)) {
+						continue;
+					}
+					bool passthrough = false;
+					for (auto &cb : child_bindings) {
+						if (cb == b) {
+							passthrough = true;
+							break;
+						}
+					}
+					if (!passthrough) {
+						// Single-column payload: the element is the packed expression.
+						// Struct payload is only ever read through struct_extract.
+						return resolve_expr(*agg_expr.GetChildren()[0]);
+					}
+				}
+			}
+		}
+		return {ArgMinOrigin::Kind::UNKNOWN, {}};
+	};
+
+	//------------------------------------------------------------------------------
+	// Build the HNSW index join (identical shape to the window-plan matcher).
+	//------------------------------------------------------------------------------
+	auto index_join = make_uniq<LogicalHNSWIndexJoin>(binder.GenerateTableIndex(), duck_table, *index_ptr, k_value);
+	for (auto &column_id : inner_get.GetColumnIds()) {
+		index_join->inner_column_ids.emplace_back(column_id.GetPrimaryIndex());
+	}
+	index_join->inner_projection_ids = inner_get.projection_ids;
+	index_join->inner_returned_types = inner_get.returned_types;
+	index_join->outer_vector_column = outer_ref_expr.Binding().column_index;
+	index_join->inner_vector_column = inner_ref_expr.Binding().column_index;
+
+	ColumnBindingReplacer replacer;
+
+	auto delim_bindings = delim_join.GetColumnBindings();
+	auto delim_types = delim_join.types;
+
+	// Resolve every delim_join output column to a physical origin BEFORE mutating the
+	// plan, so that hitting an unaccountable column leaves the plan untouched.
+	vector<ArgMinOrigin> origins;
+	origins.reserve(delim_bindings.size());
+	for (auto &db : delim_bindings) {
+		auto origin = resolve(db);
+		if (origin.kind == ArgMinOrigin::Kind::UNKNOWN) {
+			return false;
+		}
+		origins.push_back(origin);
+	}
+
+	// Top projection reproducing the delim_join output columns, expressed in terms of
+	// the index join / outer get (recomputing the distance where it is still needed).
+	vector<unique_ptr<Expression>> projection_expressions;
+	auto projection_table_index = binder.GenerateTableIndex();
+	ProjectionIndex new_binding_idx(0);
+	for (idx_t i = 0; i < delim_bindings.size(); i++) {
+		if (origins[i].kind == ArgMinOrigin::Kind::DISTANCE) {
+			// The index join does not materialise the distance; recompute it. The copy
+			// references the delim_get / inner_get and is remapped below.
+			projection_expressions.push_back(distance_expr_ptr.Copy());
+		} else {
+			projection_expressions.push_back(
+			    make_uniq<BoundColumnRefExpression>(delim_types[i], origins[i].binding));
+		}
+		replacer.replacement_bindings.emplace_back(delim_bindings[i],
+		                                           ColumnBinding(projection_table_index, new_binding_idx++));
+	}
+	auto new_projection = make_uniq<LogicalProjection>(projection_table_index, std::move(projection_expressions));
+
+	// Redirect all references to the delim_join outputs to the new projection.
+	replacer.VisitOperator(*root);
+	replacer.replacement_bindings.clear();
+
+	// Everything that used to reference the delim_get now references the outer get.
+	for (const auto &old_binding : delim_get.GetColumnBindings()) {
+		replacer.replacement_bindings.emplace_back(old_binding,
+		                                           ColumnBinding(outer_get.table_index, old_binding.column_index));
+	}
+	// Everything that used to reference the inner get now references the index join.
+	for (const auto &old_binding : inner_get.GetColumnBindings()) {
+		replacer.replacement_bindings.emplace_back(old_binding,
+		                                           ColumnBinding(index_join->table_index, old_binding.column_index));
+	}
+	replacer.VisitOperator(*new_projection);
+
+	// Assemble: index join takes the outer get as its (only) child, new projection on top.
+	index_join->children.emplace_back(std::move(*outer_get_ptr));
+	new_projection->children.emplace_back(std::move(index_join));
+	new_projection->EstimateCardinality(context);
+
+	plan = std::move(new_projection);
+
+	CardinalityResetter cardinality_resetter(context);
+	cardinality_resetter.VisitOperator(*root);
+
+	return true;
+}
+
 void HNSWIndexJoinOptimizer::OptimizeRecursive(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &root,
                                                unique_ptr<LogicalOperator> &plan) {
-	if (!TryOptimize(input.optimizer.binder, input.context, root, plan)) {
+	if (!TryOptimize(input.optimizer.binder, input.context, root, plan) &&
+	    !TryOptimizeArgMin(input.optimizer.binder, input.context, root, plan)) {
 		// Recursively optimize the children
 		for (auto &child : plan->children) {
 			OptimizeRecursive(input, root, child);

--- a/src/hnsw/hnsw_optimize_scan.cpp
+++ b/src/hnsw/hnsw_optimize_scan.cpp
@@ -136,7 +136,7 @@ public:
 			}
 
 			const auto vector_size = cast_index.GetVectorSize();
-			const auto &matched_vector = const_expr_ref.get().Cast<BoundConstantExpression>().value;
+			const auto &matched_vector = const_expr_ref.get().Cast<BoundConstantExpression>().GetValue();
 			auto query_vector = make_unsafe_uniq_array<float>(vector_size);
 			auto vector_elements = ArrayValue::GetChildren(matched_vector);
 			for (idx_t i = 0; i < vector_size; i++) {

--- a/src/hnsw/hnsw_optimize_topk.cpp
+++ b/src/hnsw/hnsw_optimize_topk.cpp
@@ -161,14 +161,14 @@ public:
 			}
 
 			const auto vector_size = cast_index.GetVectorSize();
-			const auto &matched_vector = const_expr_ref.get().Cast<BoundConstantExpression>().value;
+			const auto &matched_vector = const_expr_ref.get().Cast<BoundConstantExpression>().GetValue();
 
 			auto query_vector = make_unsafe_uniq_array<float>(vector_size);
 			auto vector_elements = ArrayValue::GetChildren(matched_vector);
 			for (idx_t i = 0; i < vector_size; i++) {
 				query_vector[i] = vector_elements[i].GetValue<float>();
 			}
-			const auto k_limit = limit_expr->Cast<BoundConstantExpression>().value.GetValue<int32_t>();
+			const auto k_limit = limit_expr->Cast<BoundConstantExpression>().GetValue().GetValue<int32_t>();
 			if (k_limit <= 0 || k_limit >= STANDARD_VECTOR_SIZE) {
 				continue;
 			}

--- a/src/include/hnsw/hnsw_index.hpp
+++ b/src/include/hnsw/hnsw_index.hpp
@@ -34,7 +34,7 @@ public:
 	using USearchIndexType = unum::usearch::index_dense_gt<row_t>;
 
 public:
-	HNSWIndex(const string &name, IndexConstraintType index_constraint_type, const vector<column_t> &column_ids,
+	HNSWIndex(const Identifier &name, IndexConstraintType index_constraint_type, const vector<column_t> &column_ids,
 	          TableIOManager &table_io_manager, const vector<unique_ptr<Expression>> &unbound_expressions,
 	          AttachedDatabase &db, const case_insensitive_map_t<Value> &options,
 	          const IndexStorageInfo &info = IndexStorageInfo(), idx_t estimated_cardinality = 0);

--- a/test/sql/hnsw/hnsw_lateral_join_plan.test
+++ b/test/sql/hnsw/hnsw_lateral_join_plan.test
@@ -1,0 +1,37 @@
+# name: test/sql/hnsw/hnsw_lateral_join_plan.test
+# description: Regression test for issue #80. A batch (LATERAL) similarity search
+#              of the form `ORDER BY array_distance(...) LIMIT k` must be planned
+#              as HNSW_INDEX_JOIN. DuckDB 1.5 rewrites this pattern into an
+#              arg_min_nulls_last top-k aggregate (TopNWindowElimination), so the
+#              HNSW optimizer must recognise that plan shape, not just the older
+#              window/row_number shape.
+# group: [hnsw]
+
+require vss
+
+statement ok
+CREATE TABLE a (a_vec FLOAT[3], a_id INT);
+
+statement ok
+CREATE TABLE b (b_vec FLOAT[3], b_str VARCHAR);
+
+statement ok
+INSERT INTO a VALUES (ARRAY[1.0, 2.0, 3.0], 1), (ARRAY[4.0, 5.0, 6.0], 2);
+
+statement ok
+INSERT INTO b VALUES (ARRAY[4.0, 5.0, 6.0], 'b'), (ARRAY[1.0, 2.0, 3.0], 'a');
+
+statement ok
+CREATE INDEX my_idx ON b USING HNSW (b_vec);
+
+# LIMIT 1: rewritten to a single-value arg_min_nulls_last aggregate.
+query II
+EXPLAIN SELECT * FROM a, LATERAL (SELECT * FROM b ORDER BY array_distance(a.a_vec, b.b_vec) LIMIT 1);
+----
+physical_plan	<REGEX>:.*HNSW_INDEX_JOIN.*
+
+# LIMIT k > 1: rewritten to a top-k arg_min_nulls_last aggregate over a struct.
+query II
+EXPLAIN SELECT * FROM a, LATERAL (SELECT * FROM b ORDER BY array_distance(a.a_vec, b.b_vec) LIMIT 2);
+----
+physical_plan	<REGEX>:.*HNSW_INDEX_JOIN.*

--- a/test/sql/hnsw/hnsw_lateral_join_plan.test
+++ b/test/sql/hnsw/hnsw_lateral_join_plan.test
@@ -4,7 +4,10 @@
 #              as HNSW_INDEX_JOIN. DuckDB 1.5 rewrites this pattern into an
 #              arg_min_nulls_last top-k aggregate (TopNWindowElimination), so the
 #              HNSW optimizer must recognise that plan shape, not just the older
-#              window/row_number shape.
+#              window/row_number shape. DuckDB's later `delim_join_as_cte` switch
+#              materialises the dependent join as a CTE, moving the arg_min subtree
+#              under an INNER comparison-join fed by a CTE_SCAN; the optimizer must
+#              match that shape too. Both settings are asserted below.
 # group: [hnsw]
 
 require vss
@@ -24,6 +27,10 @@ INSERT INTO b VALUES (ARRAY[4.0, 5.0, 6.0], 'b'), (ARRAY[1.0, 2.0, 3.0], 'a');
 statement ok
 CREATE INDEX my_idx ON b USING HNSW (b_vec);
 
+# --- delim_join_as_cte = false: the dependent join stays a DELIM_JOIN. ---
+statement ok
+SET delim_join_as_cte = false;
+
 # LIMIT 1: rewritten to a single-value arg_min_nulls_last aggregate.
 query II
 EXPLAIN SELECT * FROM a, LATERAL (SELECT * FROM b ORDER BY array_distance(a.a_vec, b.b_vec) LIMIT 1);
@@ -31,6 +38,20 @@ EXPLAIN SELECT * FROM a, LATERAL (SELECT * FROM b ORDER BY array_distance(a.a_ve
 physical_plan	<REGEX>:.*HNSW_INDEX_JOIN.*
 
 # LIMIT k > 1: rewritten to a top-k arg_min_nulls_last aggregate over a struct.
+query II
+EXPLAIN SELECT * FROM a, LATERAL (SELECT * FROM b ORDER BY array_distance(a.a_vec, b.b_vec) LIMIT 2);
+----
+physical_plan	<REGEX>:.*HNSW_INDEX_JOIN.*
+
+# --- delim_join_as_cte = true: the dependent join is materialised as a CTE. ---
+statement ok
+SET delim_join_as_cte = true;
+
+query II
+EXPLAIN SELECT * FROM a, LATERAL (SELECT * FROM b ORDER BY array_distance(a.a_vec, b.b_vec) LIMIT 1);
+----
+physical_plan	<REGEX>:.*HNSW_INDEX_JOIN.*
+
 query II
 EXPLAIN SELECT * FROM a, LATERAL (SELECT * FROM b ORDER BY array_distance(a.a_vec, b.b_vec) LIMIT 2);
 ----


### PR DESCRIPTION
Fixes #80. Builds on and supersedes #86 (by @fernandostahelin — original `TryOptimizeArgMin` work and the `GetMultiScanResult` null-buffer fix are included here, with credit).

## Why a new PR
#86 fixes the DuckDB 1.5 `arg_min` rewrite but (a) no longer compiles against current DuckDB `main` (the `linux_amd64` distribution job builds `duckdb_version: main`), and its branch lives on a fork I can't push to. This PR carries #86's commits forward, makes the whole extension compile against current `main`, and additionally handles a newer DuckDB planner change that otherwise silently disables the optimization.

## Changes on top of #86

**1. Port the extension to current DuckDB `main` (+ submodule bump).**
DuckDB `main` privatized several bound-expression fields and changed types. Migrated all access to the new accessors and the `Identifier` type:
- `BoundConstantExpression::value` → `GetValue()`
- `BoundFunctionExpression::function`/`children` → `Function()` / `GetChildren()[Mutable]`
- `BoundWindowExpression::orders` → `OrderBy()`; `BoundOperatorExpression::children` → `GetChildrenMutable()`
- `CatalogEntry::name` & friends are now `Identifier` → `.GetIdentifierName()`; `HNSWIndex`/`BoundIndex`/`ColumnRefExpression` ctors and the function matcher take `Identifier`/`identifier_set_t`
- bumped the `duckdb` submodule to a `main` commit with these accessors

**2. Match the `delim_join_as_cte` plan shape.**
DuckDB's `delim_join_as_cte` (now the default) materializes the dependent `LATERAL` top-k join as a CTE: the `arg_min` subtree then hangs off an INNER comparison-join fed by a `CTE_SCAN` instead of a `DELIM_GET`. #86's matcher only handled the `DELIM_JOIN` shape, so on default settings the optimization silently fell back to brute-force `CROSS_PRODUCT` — the exact #80 regression, but invisible to result-only tests. Added `TryOptimizeArgMinCte`, which matches the CTE shape and rewrites it to `HNSW_INDEX_JOIN`, leaving the surrounding CTE/comparison-join intact.

**3. Strengthen the regression test.**
`hnsw_lateral_join_plan.test` now asserts `HNSW_INDEX_JOIN` under **both** `delim_join_as_cte` settings (`LIMIT 1` and `k > 1`), so a future default flip can't silently regress it again.

## Testing
- Full release build against DuckDB `main` succeeds (gcc/clang, clean).
- HNSW suite: 16/16 files pass.
- Correctness verified against a brute-force baseline on default (CTE) settings: 0 mismatches for `LIMIT 1`/`3`/`5`, including projected columns and a `WHERE`-filtered case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)